### PR TITLE
Interleave pushing and updating PRs

### DIFF
--- a/docs/rfcs/rfc-execution-step-model.md
+++ b/docs/rfcs/rfc-execution-step-model.md
@@ -1,0 +1,497 @@
+# RFC: Unified Execution Step Model for Submission Plans
+
+**Status:** Approved
+**Author:** OpenCode
+**Reviewer:** dmmulroy
+**Date:** 2026-01-03  
+**Scope:** `src/submit/`, `src/cli/`, `tests/`
+
+---
+
+## Summary
+
+Refactor the submission planning system from a collection-based model (separate vectors for pushes, creates, updates, publishes) to a unified `ExecutionStep` enum with dependency-aware topological ordering. This enables correct handling of stack reordering scenarios and simplifies the execution and display logic throughout the codebase.
+
+**Amendment (2026-01-03):** Add typed `ExecutionConstraint` enum to make invalid constraint pairings unrepresentable at compile time.
+
+---
+
+## Motivation
+
+### Problem Statement
+
+The current `SubmissionPlan` structure maintains separate collections:
+
+```rust
+// BEFORE
+pub struct SubmissionPlan {
+    pub bookmarks_needing_push: Vec<Bookmark>,
+    pub prs_to_create: Vec<PrToCreate>,
+    pub prs_to_update_base: Vec<PrBaseUpdate>,
+    pub prs_to_publish: Vec<PullRequest>,
+    // ...
+}
+```
+
+This design has several deficiencies:
+
+1. **Implicit Ordering**: The execution order is hardcoded in `execute_submission()` as "push all, then update all, then create all, then publish all". This is incorrect for stack swap scenarios.
+
+2. **Stack Swap Bug**: When a user reorders commits (e.g., swapping A and B in a stack), the naive "push then retarget" order fails:
+   - If B was based on A and is now the root, we must retarget B's PR *before* pushing A
+   - Otherwise GitHub/GitLab rejects the base change due to branch history conflicts
+
+3. **Display Logic Duplication**: `submit.rs`, `sync.rs`, and `execute.rs` all have similar `if !vec.is_empty() { println!(...) }` blocks that are tedious to maintain.
+
+4. **Testing Difficulty**: Verifying execution order requires mocking the entire execution flow rather than testing the scheduler in isolation.
+
+5. **Stringly-Typed Constraints**: Edge construction uses raw `usize` indices and string-based HashMap lookups, making it easy to mix up index types or constraint endpoints without compile-time detection.
+
+### Goals
+
+- Correct handling of stack reordering scenarios
+- Single source of truth for execution order
+- Simplified display and dry-run logic via `Display` implementations
+- Isolated, unit-testable scheduler
+- **Type-safe constraint representation** — invalid constraint pairings rejected at compile time
+- Maintain backward compatibility for all existing workflows
+
+---
+
+## Design
+
+### Core Abstraction: `ExecutionStep`
+
+```rust
+pub enum ExecutionStep {
+    Push(Bookmark),
+    UpdateBase(PrBaseUpdate),
+    CreatePr(PrToCreate),
+    PublishPr(PullRequest),
+}
+```
+
+Each variant represents an atomic operation. The `SubmissionPlan` now holds an ordered `Vec<ExecutionStep>`:
+
+```rust
+// AFTER
+pub struct SubmissionPlan {
+    pub segments: Vec<NarrowedBookmarkSegment>,
+    pub constraints: Vec<ExecutionConstraint>,  // NEW: for debugging/display
+    pub execution_steps: Vec<ExecutionStep>,
+    pub existing_prs: HashMap<String, PullRequest>,
+    pub remote: String,
+    pub default_branch: String,
+}
+```
+
+### Typed Constraint System
+
+Dependencies between operations are expressed as a typed enum:
+
+```rust
+/// Typed reference to a Push operation by bookmark name.
+struct PushRef(String);
+
+/// Typed reference to an UpdateBase operation by bookmark name.
+struct UpdateRef(String);
+
+/// Typed reference to a CreatePr operation by bookmark name.
+struct CreateRef(String);
+
+/// Dependency constraint between execution operations.
+pub enum ExecutionConstraint {
+    /// Push parent branch before child branch (stack order).
+    PushOrder { parent: PushRef, child: PushRef },
+
+    /// Push new base branch before retargeting PR to it.
+    PushBeforeRetarget { base: PushRef, pr: UpdateRef },
+
+    /// Retarget PR before pushing its old base (swap scenario).
+    RetargetBeforePush { pr: UpdateRef, old_base: PushRef },
+
+    /// Push branch before creating PR for it.
+    PushBeforeCreate { push: PushRef, create: CreateRef },
+
+    /// Create parent PR before child PR (stack comment linking).
+    CreateOrder { parent: CreateRef, child: CreateRef },
+}
+```
+
+**Why typed refs?** Each constraint variant accepts only the appropriate ref types:
+
+```rust
+// COMPILE ERROR: expected PushRef, found UpdateRef
+ExecutionConstraint::PushOrder {
+    parent: UpdateRef("a".into()),  // ✗
+    child: PushRef("b".into()),
+}
+
+// CORRECT
+ExecutionConstraint::PushOrder {
+    parent: PushRef("a".into()),    // ✓
+    child: PushRef("b".into()),
+}
+```
+
+### Three-Phase Execution Planning
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌──────────────┐
+│ collect_        │───▶│ build_execution │───▶│ resolve_        │───▶│ topo_sort_   │
+│ constraints()   │    │ _nodes()        │    │ constraints()   │    │ steps()      │
+└─────────────────┘    └─────────────────┘    └─────────────────┘    └──────────────┘
+  Declarative           Nodes + Registry       Edges (Vec<Vec<       Sorted steps
+  constraints           (NodeRegistry)         usize>>)
+```
+
+1. **collect_constraints()**: Build typed `ExecutionConstraint` values declaratively, without indices
+2. **build_execution_nodes()**: Create nodes and populate `NodeRegistry` mapping bookmark names to indices
+3. **resolve_constraints()**: Convert constraints to `(from, to)` edges via registry lookup
+4. **topo_sort_steps()**: Kahn's algorithm produces final execution order
+
+### Node Registry
+
+```rust
+#[derive(Debug, Clone, Copy)]
+struct NodeIdx(usize);
+
+#[derive(Debug, Default)]
+struct NodeRegistry {
+    push: HashMap<String, NodeIdx>,
+    update: HashMap<String, NodeIdx>,
+    create: HashMap<String, NodeIdx>,
+    publish: HashMap<String, NodeIdx>,
+}
+
+impl ExecutionConstraint {
+    /// Resolve to (from, to) indices, or None if endpoint missing.
+    fn resolve(&self, registry: &NodeRegistry) -> Option<(usize, usize)> {
+        match self {
+            Self::PushOrder { parent, child } => {
+                let from = registry.push.get(&parent.0)?;
+                let to = registry.push.get(&child.0)?;
+                Some((from.0, to.0))
+            }
+            // ... other variants
+        }
+    }
+}
+```
+
+**Why `Option`?** Constraints may reference operations that don't exist in the plan (e.g., an already-synced bookmark has no `Push` node). Silent skipping is semantically correct here.
+
+### Topological Sort (Kahn's Algorithm)
+
+We use Kahn's algorithm to produce a valid execution order from the dependency DAG.
+
+**Algorithm overview:**
+1. Compute in-degree (incoming edge count) for each node
+2. Initialize a ready queue with all nodes having in-degree=0
+3. Loop: pop node from queue → emit to output → decrement in-degree of all successors → enqueue any successor that reaches in-degree=0
+4. If output length < node count, a cycle exists (some nodes never became ready)
+
+**Why Kahn's algorithm:**
+- Naturally handles DAG constraints (dependencies satisfied before dependents)
+- Cycle detection is free (unreachable nodes indicate cycles)
+- Deterministic ordering via min-heap keyed by `(insertion_order, node_idx)` as tiebreaker when multiple nodes are ready simultaneously
+
+```rust
+fn topo_sort_steps(nodes: &[ExecutionNode], edges: &[Vec<usize>]) -> Result<Vec<ExecutionStep>>
+```
+
+### Execution Loop
+
+The executor becomes a simple dispatch loop:
+
+```rust
+for step in &plan.execution_steps {
+    let outcome = execute_step(step, workspace, platform, remote, progress).await;
+    match outcome {
+        StepOutcome::Success(pr) => { /* track PR */ }
+        StepOutcome::FatalError(msg) => { result.fail(msg); return Ok(result); }
+        StepOutcome::SoftError(msg) => { result.soft_fail(msg); }
+    }
+}
+```
+
+### Display Implementation
+
+Each enum gains a `Display` impl:
+
+```rust
+impl Display for ExecutionStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Push(bm) => write!(f, "push {}", bm.name),
+            Self::CreatePr(c) => write!(f, "create PR {} -> {} ({})", ...),
+            // ...
+        }
+    }
+}
+
+impl Display for ExecutionConstraint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PushOrder { parent, child } => {
+                write!(f, "Push({}) → Push({})", parent.0, child.0)
+            }
+            // ...
+        }
+    }
+}
+```
+
+CLI display code collapses from ~80 lines to:
+
+```rust
+for step in &plan.execution_steps {
+    println!("    -> {step}");
+}
+```
+
+---
+
+## Type Safety Analysis
+
+### What Invalid States Are Now Unrepresentable
+
+| Invalid State | How Prevented |
+|---------------|---------------|
+| `PushBeforeCreate { push: UpdateRef(...), ... }` | Compile error: expected `PushRef` |
+| `CreateOrder { parent: PushRef(...), ... }` | Compile error: expected `CreateRef` |
+| Anonymous `add_edge(3, 7)` without semantic meaning | Must use `ExecutionConstraint` enum |
+| Missing match arm when adding new constraint type | Exhaustive match in `resolve()` |
+
+### What Is NOT Prevented (Acceptable)
+
+| Risk | Mitigation |
+|------|------------|
+| Typos in bookmark names | Runtime: constraint resolves to `None`, edge skipped |
+| Cycles in constraint graph | Runtime: Kahn's algorithm detects, returns `Error::SchedulerCycle` |
+| Forgetting a constraint | Code review, tests verify ordering |
+
+---
+
+## Changes Summary
+
+| File | Lines Changed | Description |
+|------|---------------|-------------|
+| `src/submit/plan.rs` | +600 | `ExecutionStep`, `ExecutionConstraint`, typed refs, topo sort |
+| `src/submit/execute.rs` | +200 | `StepOutcome`, step executors, simplified orchestrator |
+| `src/submit/progress.rs` | +15 | `Phase::Executing` replaces 4 separate phases |
+| `src/submit/mod.rs` | +5 | Export `ExecutionConstraint` |
+| `src/cli/submit.rs` | -50 | Simplified plan preview and option application |
+| `src/cli/sync.rs` | -20 | Simplified plan display |
+| `src/cli/progress.rs` | -20 | Use `Display` impls |
+| `tests/*.rs` | +40 | Adapt to `execution_steps` API, add constraint field |
+| `tests/execution_step_tests.rs` | +500 | **NEW**: Integration tests for step ordering |
+| `tests/e2e_tests.rs` | +120 | **NEW**: E2E tests for swap/mixed operations |
+| `tests/common/temp_repo.rs` | +50 | `TempJjRepo` helpers: `rebase_before`, `move_bookmark`, etc. |
+| `tests/common/fixtures.rs` | +15 | `make_pr_draft` helper |
+
+**Total:** ~+1500 lines net, including ~150 lines of type definitions and ~700 lines of tests.
+
+---
+
+## Trade-offs and Alternatives
+
+### Alternative: Keep Separate Collections + Sort Key
+
+Add a `sort_key: usize` to each operation, sort before execution.
+
+**Rejected**: Doesn't express inter-operation dependencies, only total ordering. The swap case requires conditional ordering that a simple key cannot express.
+
+### Alternative: Multi-Phase with Explicit Swap Detection
+
+Keep current structure, add a "swap detection" pre-pass that reorders operations.
+
+**Rejected**: Fragile heuristics, doesn't generalize to complex multi-swap scenarios.
+
+### Alternative: Typed Node Indices Instead of Typed Constraints
+
+Use `PushIdx`, `CreateIdx` newtypes for indices rather than constraint-level typing.
+
+**Rejected**: Prevents mixing index types but doesn't document *why* edges exist. The `ExecutionConstraint` enum is self-documenting and allows storing constraints for debugging.
+
+### Alternative: Builder Pattern for Graph Construction
+
+Use a builder that returns typed handles from `add_push()`, `add_create()`, etc.
+
+**Rejected**: Introduces cross-builder bug risk (handles from builder A used with builder B). Declarative constraint collection is cleaner.
+
+### Trade-off: Memory Overhead
+
+`ExecutionStep` and `ExecutionConstraint` enums with cloned data. For typical stacks (2-10 PRs), this is negligible (~10KB). Acceptable.
+
+### Trade-off: Complexity
+
+The typed constraint system adds ~100 lines of type definitions. This is offset by:
+- Compile-time rejection of invalid constraint pairings
+- Self-documenting constraint vocabulary (enum variants)
+- Debug logging of constraints before resolution
+
+---
+
+## Testing Strategy
+
+### Unit Tests (`src/submit/plan.rs`)
+
+| Test | Validates |
+|------|-----------|
+| `test_execution_steps_simple_push_order` | Pushes follow stack order |
+| `test_execution_steps_push_before_create` | Push precedes PR creation |
+| `test_execution_steps_create_order_follows_stack` | Creates follow stack order |
+| `test_execution_steps_swap_order` | **Critical**: retarget before push in swap case |
+
+### Integration Tests (`tests/execution_step_tests.rs`)
+
+Tests using real jj repositories via `TempJjRepo` to validate ordering with actual workspace state:
+
+| Test | Validates |
+|------|-----------|
+| `test_swap_scenario_retarget_before_push` | **Critical**: A→B to B→A swap ordering |
+| `test_three_level_swap_middle_to_root` | 3-level stack reordering |
+| `test_push_order_follows_stack_structure` | 4-deep stack push ordering |
+| `test_create_order_respects_stack_for_comment_linking` | `CreatePr` follows stack for parent refs |
+| `test_push_before_create_constraint` | `Push(X)` before `CreatePr(X)` |
+| `test_push_before_retarget_constraint` | `Push(base)` before `UpdateBase(pr)` |
+| `test_partial_existing_prs_mixed_operations` | Mixed Push/Update/Create ordering |
+| `test_draft_pr_in_stack` | Draft PR handling |
+| `test_constraints_skip_synced_bookmarks` | Graceful constraint skipping |
+| `test_all_prs_exist_correct_bases` | Minimal operations scenario |
+| `test_ten_level_stack_ordering` | 10-level stress test |
+| `test_constraint_display_formatting` | `ExecutionConstraint::Display` impl |
+| `test_scheduler_cycle_error_format` | `Error::SchedulerCycle` structure |
+
+### E2E Tests (`tests/e2e_tests.rs`)
+
+Real GitHub API tests validating execution ordering against live platform (require `JJ_RYU_E2E_TESTS=1`):
+
+| Test | Validates |
+|------|-----------|
+| `test_stack_swap_reorder` | Swap works against real GitHub API |
+| `test_mixed_operations_ordering` | Mixed ops with real API |
+| `test_insert_middle_of_stack` | Insert commit + base update |
+
+### Test Infrastructure
+
+`TempJjRepo` helpers for stack manipulation:
+- `rebase_before(rev, before)` — Swap commits via `jj rebase -r REV --before TARGET`
+- `move_bookmark(name, to_rev)` — Move bookmark to different revision
+- `change_id(bookmark)` — Get change ID for a bookmark
+
+Fixture helpers:
+- `make_pr_draft(number, head, base)` — Create draft PR fixture
+
+---
+
+## Migration & Compatibility
+
+### API Changes (Library Crate)
+
+| Before | After |
+|--------|-------|
+| `plan.prs_to_create` | `plan.execution_steps.iter().filter_map(...)` |
+| `plan.bookmarks_needing_push` | `plan.count_pushes()` or filter |
+| N/A | `plan.constraints` (new field for debugging) |
+
+The old fields are **removed**, not deprecated. Library consumers must update.
+
+### CLI Behavior
+
+Unchanged. Users see the same output, just generated via `Display` rather than hardcoded strings.
+
+### CLI Flag Semantics: `--draft` and `--publish`
+
+`PublishPr` steps are added post-planning by `apply_plan_options()` rather than during constraint resolution. This is safe because:
+
+1. `--publish` only affects PRs in `existing_prs` (from previous runs)
+2. Publishing has no ordering dependencies with other operations
+3. PRs created in the current run are not in `existing_prs`
+
+**Flag precedence**: When both `--draft` and `--publish` are specified, `--publish` takes precedence and `--draft` is ignored. This ensures predictable behavior:
+
+| Flags | New PRs | Existing Draft PRs |
+|-------|---------|-------------------|
+| (none) | normal | unchanged |
+| `--draft` | draft | unchanged |
+| `--publish` | normal | published |
+| `--draft --publish` | normal | published |
+
+### Progress Phases
+
+```rust
+// BEFORE
+Phase::Pushing, Phase::CreatingPrs, Phase::UpdatingPrs, Phase::PublishingPrs
+
+// AFTER  
+Phase::Executing  // single phase for all operations
+```
+
+---
+
+## Debug Logging
+
+The constraint system adds structured debug logging:
+
+```rust
+tracing::debug!(constraint_count = constraints.len(), "Collected execution constraints");
+
+// Per-constraint resolution (trace level)
+tracing::trace!(%constraint, from, to, "Resolved constraint to edge");
+tracing::trace!(%constraint, "Constraint skipped (endpoint not in plan)");
+```
+
+Enable with `RUST_LOG=jj_ryu::submit::plan=debug` for constraint counts, or `=trace` for per-constraint details.
+
+---
+
+## Security Considerations
+
+None. This is a pure refactoring of internal scheduling logic. No new external inputs, no authentication changes, no new network calls.
+
+---
+
+## Questions & Decisions
+
+1. **Parallelization**: Sequential execution only. Parallel API calls add complexity and rate-limit concerns; current perf is acceptable.
+
+2. **Undo/Rollback**: No rollback on failure. PRs are idempotent; users can `ryu submit` again after fixing issues.
+
+3. **Cycle Detection UX**: Dedicated `Error::SchedulerCycle` variant with:
+   - Message explaining this is a bug, not user error
+   - List of cycle node descriptions for debugging
+   - `tracing::error!` log with cycle details
+   
+   ```rust
+   Error::SchedulerCycle {
+       message: String,
+       cycle_nodes: Vec<String>,  // e.g., ["push feature-a", "update feature-b"]
+   }
+   ```
+
+4. **Store constraints in plan?** **Yes** — enables debugging and potential dry-run display of dependencies.
+
+5. **More granular `NodeIdx` types?** **No** — `PushIdx`, `CreateIdx` etc. adds boilerplate without significant benefit since resolution already type-checks via registry maps.
+
+---
+
+## Conclusion
+
+This RFC proposes replacing the implicit, collection-based execution model with an explicit, dependency-aware `ExecutionStep` model, enhanced with a typed `ExecutionConstraint` system. The key benefits are:
+
+1. **Correctness**: Stack swap scenarios work correctly
+2. **Type Safety**: Invalid constraint pairings rejected at compile time
+3. **Simplicity**: Display and execution logic reduced by ~150 lines
+4. **Testability**: Scheduler can be unit-tested in isolation
+5. **Debuggability**: Constraints stored in plan, available for logging
+6. **Maintainability**: Single source of truth for operation ordering; self-documenting constraint vocabulary
+
+The implementation is complete and all existing tests pass after adaptation.
+
+**Test coverage added (2026-01-03):**
+- 13 integration tests in `tests/execution_step_tests.rs` using real jj workspaces
+- 3 E2E tests in `tests/e2e_tests.rs` validating against real GitHub API
+- `TempJjRepo` helpers for stack reordering (`rebase_before`, `move_bookmark`)
+- `make_pr_draft` fixture helper

--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -31,23 +31,10 @@ impl CliProgress {
 impl ProgressCallback for CliProgress {
     async fn on_phase(&self, phase: Phase) {
         if self.verbose {
-            match phase {
-                Phase::Analyzing => println!("Analyzing..."),
-                Phase::Planning => println!("Planning..."),
-                Phase::Pushing => println!("Pushing bookmarks..."),
-                Phase::CreatingPrs => println!("Creating PRs..."),
-                Phase::UpdatingPrs => println!("Updating PRs..."),
-                Phase::PublishingPrs => println!("Publishing draft PRs..."),
-                Phase::AddingComments => println!("Updating stack comments..."),
-                Phase::Complete => println!("Done!"),
-            }
+            println!("{phase}...");
         } else {
             match phase {
-                Phase::Pushing => println!("  Pushing bookmarks..."),
-                Phase::CreatingPrs => println!("  Creating PRs..."),
-                Phase::UpdatingPrs => println!("  Updating PRs..."),
-                Phase::PublishingPrs => println!("  Publishing drafts..."),
-                Phase::AddingComments => println!("  Updating comments..."),
+                Phase::Executing | Phase::AddingComments => println!("  {phase}..."),
                 _ => {}
             }
         }
@@ -55,18 +42,17 @@ impl ProgressCallback for CliProgress {
 
     async fn on_bookmark_push(&self, bookmark: &str, status: PushStatus) {
         if self.verbose {
-            match status {
+            match &status {
                 PushStatus::Started => println!("  Pushing {bookmark}..."),
                 PushStatus::Success => println!("  ✓ Pushed {bookmark}"),
-                PushStatus::AlreadySynced => println!("  - {bookmark} already synced"),
-                PushStatus::Failed(msg) => println!("  ✗ Failed to push {bookmark}: {msg}"),
+                PushStatus::AlreadySynced => println!("  - {bookmark} {status}"),
+                PushStatus::Failed(_) => println!("  ✗ Failed to push {bookmark}: {status}"),
             }
         } else {
-            match status {
+            match &status {
                 PushStatus::Started => print!("    Pushing {bookmark}... "),
                 PushStatus::Success => println!("done"),
-                PushStatus::AlreadySynced => println!("already synced"),
-                PushStatus::Failed(msg) => println!("failed: {msg}"),
+                _ => println!("{status}"),
             }
         }
     }

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -166,35 +166,15 @@ fn print_sync_preview(stack_plans: &[(&str, SubmissionPlan)]) {
     for (leaf_bookmark, plan) in stack_plans {
         println!("Stack: {leaf_bookmark}");
 
-        if !plan.bookmarks_needing_push.is_empty() {
-            println!("  Push:");
-            for bm in &plan.bookmarks_needing_push {
-                println!("    - {}", bm.name);
-            }
-        }
-
-        if !plan.prs_to_create.is_empty() {
-            println!("  Create PRs:");
-            for pr in &plan.prs_to_create {
-                println!("    - {} → {}", pr.bookmark.name, pr.base_branch);
-            }
-        }
-
-        if !plan.prs_to_update_base.is_empty() {
-            println!("  Update PR bases:");
-            for update in &plan.prs_to_update_base {
-                println!(
-                    "    - {} {} → {}",
-                    update.bookmark.name, update.current_base, update.expected_base
-                );
-            }
-        }
-
-        if plan.bookmarks_needing_push.is_empty()
-            && plan.prs_to_create.is_empty()
-            && plan.prs_to_update_base.is_empty()
-        {
+        if plan.execution_steps.is_empty() {
             println!("  Already in sync");
+            println!();
+            continue;
+        }
+
+        println!("  Steps:");
+        for step in &plan.execution_steps {
+            println!("    → {step}");
         }
 
         println!();

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,15 @@ pub enum Error {
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// Scheduler detected a cycle in execution dependencies (indicates a bug)
+    #[error("scheduler cycle detected: {message}")]
+    SchedulerCycle {
+        /// Human-readable description
+        message: String,
+        /// Node names involved in the cycle (for debugging)
+        cycle_nodes: Vec<String>,
+    },
+
     /// Invalid command-line argument
     #[error("invalid argument: {0}")]
     InvalidArgument(String),

--- a/src/submit/execute.rs
+++ b/src/submit/execute.rs
@@ -5,15 +5,16 @@
 use crate::error::{Error, Result};
 use crate::platform::PlatformService;
 use crate::repo::JjWorkspace;
-use crate::submit::{Phase, ProgressCallback, PushStatus, SubmissionPlan};
-use crate::types::PullRequest;
+use crate::submit::plan::{PrBaseUpdate, PrToCreate};
+use crate::submit::{ExecutionStep, Phase, ProgressCallback, PushStatus, SubmissionPlan};
+use crate::types::{Bookmark, PullRequest};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Write;
 
 /// Result of submission execution
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SubmissionResult {
     /// Whether execution succeeded
     pub success: bool,
@@ -25,6 +26,38 @@ pub struct SubmissionResult {
     pub pushed_bookmarks: Vec<String>,
     /// Errors encountered (non-fatal)
     pub errors: Vec<String>,
+}
+
+impl SubmissionResult {
+    /// Create a new successful result
+    pub fn new() -> Self {
+        Self {
+            success: true,
+            ..Default::default()
+        }
+    }
+
+    /// Record a fatal error and mark as failed
+    pub fn fail(&mut self, error: String) {
+        self.errors.push(error);
+        self.success = false;
+    }
+
+    /// Record a non-fatal error (soft fail)
+    pub fn soft_fail(&mut self, error: String) {
+        self.errors.push(error);
+    }
+}
+
+/// Outcome of executing a single step
+#[derive(Debug)]
+pub enum StepOutcome {
+    /// Step succeeded, optionally with a PR to track
+    Success(Option<(String, PullRequest)>),
+    /// Step failed fatally - stop execution
+    FatalError(String),
+    /// Step failed but execution should continue (soft fail)
+    SoftError(String),
 }
 
 /// Stack comment data embedded in PR comments
@@ -55,14 +88,86 @@ pub const COMMENT_DATA_POSTFIX: &str = " --->";
 /// Marker for the current PR in stack comments
 pub const STACK_COMMENT_THIS_PR: &str = "👈";
 
+// =============================================================================
+// Step Execution Functions (testable in isolation)
+// =============================================================================
+
+/// Execute a push step
+pub fn execute_push(
+    workspace: &mut JjWorkspace,
+    bookmark: &Bookmark,
+    remote: &str,
+) -> StepOutcome {
+    match workspace.git_push(&bookmark.name, remote) {
+        Ok(()) => StepOutcome::Success(None),
+        Err(e) => StepOutcome::FatalError(format!("Failed to push {}: {e}", bookmark.name)),
+    }
+}
+
+/// Execute an update base step
+pub async fn execute_update_base(
+    platform: &dyn PlatformService,
+    update: &PrBaseUpdate,
+) -> StepOutcome {
+    match platform
+        .update_pr_base(update.pr.number, &update.expected_base)
+        .await
+    {
+        Ok(updated_pr) => {
+            StepOutcome::Success(Some((update.bookmark.name.clone(), updated_pr)))
+        }
+        Err(e) => StepOutcome::FatalError(format!(
+            "Failed to update PR base for {}: {e}",
+            update.bookmark.name
+        )),
+    }
+}
+
+/// Execute a create PR step
+pub async fn execute_create_pr(
+    platform: &dyn PlatformService,
+    create: &PrToCreate,
+) -> StepOutcome {
+    match platform
+        .create_pr_with_options(
+            &create.bookmark.name,
+            &create.base_branch,
+            &create.title,
+            create.draft,
+        )
+        .await
+    {
+        Ok(pr) => StepOutcome::Success(Some((create.bookmark.name.clone(), pr))),
+        Err(e) => StepOutcome::FatalError(format!(
+            "Failed to create PR for {}: {e}",
+            create.bookmark.name
+        )),
+    }
+}
+
+/// Execute a publish PR step (soft fail on error)
+pub async fn execute_publish_pr(
+    platform: &dyn PlatformService,
+    pr: &PullRequest,
+) -> StepOutcome {
+    match platform.publish_pr(pr.number).await {
+        Ok(updated_pr) => StepOutcome::Success(Some((pr.head_ref.clone(), updated_pr))),
+        Err(e) => StepOutcome::SoftError(format!("Failed to publish PR #{}: {e}", pr.number)),
+    }
+}
+
+// =============================================================================
+// Main Execution Orchestrator
+// =============================================================================
+
 /// Execute a submission plan
 ///
 /// This performs the actual operations:
 /// 1. Push bookmarks to remote
 /// 2. Update PR bases
 /// 3. Create new PRs
-/// 4. Add/update stack comments
-#[allow(clippy::too_many_lines)]
+/// 4. Publish draft PRs
+/// 5. Add/update stack comments
 pub async fn execute_submission(
     plan: &SubmissionPlan,
     workspace: &mut JjWorkspace,
@@ -70,13 +175,7 @@ pub async fn execute_submission(
     progress: &dyn ProgressCallback,
     dry_run: bool,
 ) -> Result<SubmissionResult> {
-    let mut result = SubmissionResult {
-        success: true,
-        created_prs: Vec::new(),
-        updated_prs: Vec::new(),
-        pushed_bookmarks: Vec::new(),
-        errors: Vec::new(),
-    };
+    let mut result = SubmissionResult::new();
 
     if dry_run {
         progress
@@ -89,126 +188,38 @@ pub async fn execute_submission(
     // Track all PRs (existing + created) for comment generation
     let mut bookmark_to_pr: HashMap<String, PullRequest> = plan.existing_prs.clone();
 
-    // Phase: Pushing bookmarks
-    progress.on_phase(Phase::Pushing).await;
+    // Phase: Executing all steps
+    progress.on_phase(Phase::Executing).await;
 
-    for bookmark in &plan.bookmarks_needing_push {
-        progress
-            .on_bookmark_push(&bookmark.name, PushStatus::Started)
-            .await;
+    for step in &plan.execution_steps {
+        let outcome = execute_step(step, workspace, platform, &plan.remote, progress).await;
 
-        match workspace.git_push(&bookmark.name, &plan.remote) {
-            Ok(()) => {
-                progress
-                    .on_bookmark_push(&bookmark.name, PushStatus::Success)
-                    .await;
-                result.pushed_bookmarks.push(bookmark.name.clone());
-            }
-            Err(e) => {
-                let msg = format!("Failed to push {}: {e}", bookmark.name);
-                progress
-                    .on_bookmark_push(&bookmark.name, PushStatus::Failed(msg.clone()))
-                    .await;
-                result.errors.push(msg);
-                result.success = false;
-                return Ok(result);
-            }
-        }
-    }
-
-    // Phase: Updating PR bases
-    progress.on_phase(Phase::UpdatingPrs).await;
-
-    for update in &plan.prs_to_update_base {
-        progress
-            .on_message(&format!(
-                "Updating {} base: {} → {}",
-                update.bookmark.name, update.current_base, update.expected_base
-            ))
-            .await;
-
-        match platform
-            .update_pr_base(update.pr.number, &update.expected_base)
-            .await
-        {
-            Ok(updated_pr) => {
-                progress
-                    .on_pr_updated(&update.bookmark.name, &updated_pr)
-                    .await;
-                result.updated_prs.push(updated_pr.clone());
-                bookmark_to_pr.insert(update.bookmark.name.clone(), updated_pr);
-            }
-            Err(e) => {
-                let msg = format!("Failed to update PR base for {}: {e}", update.bookmark.name);
-                progress.on_error(&Error::Platform(msg.clone())).await;
-                result.errors.push(msg);
-                result.success = false;
-                return Ok(result);
-            }
-        }
-    }
-
-    // Phase: Creating PRs
-    progress.on_phase(Phase::CreatingPrs).await;
-
-    for pr_to_create in &plan.prs_to_create {
-        let draft_str = if pr_to_create.draft { " [draft]" } else { "" };
-        progress
-            .on_message(&format!(
-                "Creating PR for {} (base: {}){draft_str}",
-                pr_to_create.bookmark.name, pr_to_create.base_branch
-            ))
-            .await;
-
-        match platform
-            .create_pr_with_options(
-                &pr_to_create.bookmark.name,
-                &pr_to_create.base_branch,
-                &pr_to_create.title,
-                pr_to_create.draft,
-            )
-            .await
-        {
-            Ok(pr) => {
-                progress
-                    .on_pr_created(&pr_to_create.bookmark.name, &pr)
-                    .await;
-                result.created_prs.push(pr.clone());
-                bookmark_to_pr.insert(pr_to_create.bookmark.name.clone(), pr);
-            }
-            Err(e) => {
-                let msg = format!(
-                    "Failed to create PR for {}: {e}",
-                    pr_to_create.bookmark.name
-                );
-                progress.on_error(&Error::Platform(msg.clone())).await;
-                result.errors.push(msg);
-                result.success = false;
-                return Ok(result);
-            }
-        }
-    }
-
-    // Phase: Publishing draft PRs
-    if !plan.prs_to_publish.is_empty() {
-        progress.on_phase(Phase::PublishingPrs).await;
-
-        for pr in &plan.prs_to_publish {
-            progress
-                .on_message(&format!("Publishing PR #{} ({})", pr.number, pr.head_ref))
-                .await;
-
-            match platform.publish_pr(pr.number).await {
-                Ok(updated_pr) => {
-                    result.updated_prs.push(updated_pr.clone());
-                    bookmark_to_pr.insert(pr.head_ref.clone(), updated_pr);
+        match outcome {
+            StepOutcome::Success(Some((bookmark, pr))) => {
+                // Track the PR for comment generation
+                match step {
+                    ExecutionStep::CreatePr(_) => result.created_prs.push(pr.clone()),
+                    ExecutionStep::UpdateBase(_) | ExecutionStep::PublishPr(_) => {
+                        result.updated_prs.push(pr.clone());
+                    }
+                    ExecutionStep::Push(_) => {}
                 }
-                Err(e) => {
-                    let msg = format!("Failed to publish PR #{}: {e}", pr.number);
-                    progress.on_error(&Error::Platform(msg.clone())).await;
-                    result.errors.push(msg);
-                    // Don't fail the whole submission for publish errors
+                bookmark_to_pr.insert(bookmark, pr);
+            }
+            StepOutcome::Success(None) => {
+                // Push succeeded - track it
+                if let ExecutionStep::Push(bm) = step {
+                    result.pushed_bookmarks.push(bm.name.clone());
                 }
+            }
+            StepOutcome::FatalError(msg) => {
+                progress.on_error(&Error::Platform(msg.clone())).await;
+                result.fail(msg);
+                return Ok(result);
+            }
+            StepOutcome::SoftError(msg) => {
+                progress.on_error(&Error::Platform(msg.clone())).await;
+                result.soft_fail(msg);
             }
         }
     }
@@ -228,8 +239,7 @@ pub async fn execute_submission(
                     item.bookmark_name
                 );
                 progress.on_error(&Error::Platform(msg.clone())).await;
-                result.errors.push(msg);
-                // Don't fail the whole submission for comment errors
+                result.soft_fail(msg);
             }
         }
     }
@@ -239,51 +249,114 @@ pub async fn execute_submission(
     Ok(result)
 }
 
-/// Report what would be done in a dry run
-async fn report_dry_run(plan: &SubmissionPlan, progress: &dyn ProgressCallback) {
-    if !plan.bookmarks_needing_push.is_empty() {
-        progress.on_message("Would push:").await;
-        for bm in &plan.bookmarks_needing_push {
+/// Execute a single step with progress reporting
+async fn execute_step(
+    step: &ExecutionStep,
+    workspace: &mut JjWorkspace,
+    platform: &dyn PlatformService,
+    remote: &str,
+    progress: &dyn ProgressCallback,
+) -> StepOutcome {
+    match step {
+        ExecutionStep::Push(bookmark) => {
             progress
-                .on_message(&format!("  - {} to {}", bm.name, plan.remote))
+                .on_bookmark_push(&bookmark.name, PushStatus::Started)
                 .await;
-        }
-    }
 
-    if !plan.prs_to_update_base.is_empty() {
-        progress.on_message("Would update PR bases:").await;
-        for update in &plan.prs_to_update_base {
+            let outcome = execute_push(workspace, bookmark, remote);
+
+            match &outcome {
+                StepOutcome::Success(_) => {
+                    progress
+                        .on_bookmark_push(&bookmark.name, PushStatus::Success)
+                        .await;
+                }
+                StepOutcome::FatalError(msg) | StepOutcome::SoftError(msg) => {
+                    progress
+                        .on_bookmark_push(&bookmark.name, PushStatus::Failed(msg.clone()))
+                        .await;
+                }
+            }
+
+            outcome
+        }
+
+        ExecutionStep::UpdateBase(update) => {
             progress
                 .on_message(&format!(
-                    "  - {} (PR #{}) {} → {}",
-                    update.bookmark.name,
-                    update.pr.number,
-                    update.current_base,
-                    update.expected_base
+                    "Updating {} base: {} → {}",
+                    update.bookmark.name, update.current_base, update.expected_base
                 ))
                 .await;
-        }
-    }
 
-    if !plan.prs_to_create.is_empty() {
-        progress.on_message("Would create PRs:").await;
-        for pr in &plan.prs_to_create {
+            let outcome = execute_update_base(platform, update).await;
+
+            if let StepOutcome::Success(Some((bookmark, pr))) = &outcome {
+                progress.on_pr_updated(bookmark, pr).await;
+            }
+
+            outcome
+        }
+
+        ExecutionStep::CreatePr(create) => {
+            let draft_str = if create.draft { " [draft]" } else { "" };
             progress
                 .on_message(&format!(
-                    "  - {} → {} ({})",
-                    pr.bookmark.name, pr.base_branch, pr.title
+                    "Creating PR for {} (base: {}){draft_str}",
+                    create.bookmark.name, create.base_branch
                 ))
                 .await;
-        }
-    }
 
-    if plan.bookmarks_needing_push.is_empty()
-        && plan.prs_to_update_base.is_empty()
-        && plan.prs_to_create.is_empty()
-    {
-        progress.on_message("Nothing to do - already in sync").await;
+            let outcome = execute_create_pr(platform, create).await;
+
+            if let StepOutcome::Success(Some((bookmark, pr))) = &outcome {
+                progress.on_pr_created(bookmark, pr).await;
+            }
+
+            outcome
+        }
+
+        ExecutionStep::PublishPr(pr) => {
+            progress
+                .on_message(&format!("Publishing PR #{} ({})", pr.number, pr.head_ref))
+                .await;
+
+            execute_publish_pr(platform, pr).await
+        }
     }
 }
+
+// =============================================================================
+// Dry Run Reporting
+// =============================================================================
+
+/// Report what would be done in a dry run
+async fn report_dry_run(plan: &SubmissionPlan, progress: &dyn ProgressCallback) {
+    if plan.execution_steps.is_empty() {
+        progress.on_message("Nothing to do - already in sync").await;
+        return;
+    }
+
+    progress.on_message("Would execute:").await;
+    for step in &plan.execution_steps {
+        let msg = format_step_for_dry_run(step, &plan.remote);
+        progress.on_message(&msg).await;
+    }
+}
+
+/// Format a step for dry run output
+pub fn format_step_for_dry_run(step: &ExecutionStep, remote: &str) -> String {
+    match step {
+        // Push needs special handling to include remote
+        ExecutionStep::Push(bm) => format!("  → push {} to {}", bm.name, remote),
+        // All other steps use Display impl
+        _ => format!("  → {step}"),
+    }
+}
+
+// =============================================================================
+// Stack Comment Functions
+// =============================================================================
 
 /// Build stack comment data from the plan and PRs
 #[allow(clippy::implicit_hasher)]
@@ -360,10 +433,14 @@ async fn create_or_update_stack_comment(
     Ok(())
 }
 
+// =============================================================================
+// Tests
+// =============================================================================
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Bookmark;
+    use crate::types::NarrowedBookmarkSegment;
 
     fn make_pr(number: u64, bookmark: &str) -> PullRequest {
         PullRequest {
@@ -387,10 +464,126 @@ mod tests {
         }
     }
 
+    // === SubmissionResult tests ===
+
+    #[test]
+    fn test_submission_result_new() {
+        let result = SubmissionResult::new();
+        assert!(result.success);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn test_submission_result_fail() {
+        let mut result = SubmissionResult::new();
+        result.fail("something went wrong".to_string());
+
+        assert!(!result.success);
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0], "something went wrong");
+    }
+
+    #[test]
+    fn test_submission_result_soft_fail() {
+        let mut result = SubmissionResult::new();
+        result.soft_fail("minor issue".to_string());
+
+        // Soft fail records error but doesn't mark as failed
+        assert!(result.success);
+        assert_eq!(result.errors.len(), 1);
+    }
+
+    // === StepOutcome tests ===
+
+    #[test]
+    fn test_step_outcome_success_without_pr() {
+        let outcome = StepOutcome::Success(None);
+        assert!(matches!(outcome, StepOutcome::Success(None)));
+    }
+
+    #[test]
+    fn test_step_outcome_success_with_pr() {
+        let pr = make_pr(1, "feat-a");
+        let outcome = StepOutcome::Success(Some(("feat-a".to_string(), pr)));
+        assert!(matches!(outcome, StepOutcome::Success(Some(_))));
+    }
+
+    #[test]
+    fn test_step_outcome_fatal_error() {
+        let outcome = StepOutcome::FatalError("boom".to_string());
+        assert!(matches!(outcome, StepOutcome::FatalError(_)));
+    }
+
+    #[test]
+    fn test_step_outcome_soft_error() {
+        let outcome = StepOutcome::SoftError("minor".to_string());
+        assert!(matches!(outcome, StepOutcome::SoftError(_)));
+    }
+
+    // === Dry run formatting tests ===
+
+    #[test]
+    fn test_format_step_push() {
+        let bm = make_bookmark("feat-a");
+        let step = ExecutionStep::Push(bm);
+        let output = format_step_for_dry_run(&step, "origin");
+        assert_eq!(output, "  → push feat-a to origin");
+    }
+
+    #[test]
+    fn test_format_step_create_pr() {
+        let bm = make_bookmark("feat-a");
+        let create = PrToCreate {
+            bookmark: bm,
+            base_branch: "main".to_string(),
+            title: "Add feature".to_string(),
+            draft: false,
+        };
+        let step = ExecutionStep::CreatePr(create);
+        let output = format_step_for_dry_run(&step, "origin");
+        assert_eq!(output, "  → create PR feat-a → main (Add feature)");
+    }
+
+    #[test]
+    fn test_format_step_create_pr_draft() {
+        let bm = make_bookmark("feat-a");
+        let create = PrToCreate {
+            bookmark: bm,
+            base_branch: "main".to_string(),
+            title: "Add feature".to_string(),
+            draft: true,
+        };
+        let step = ExecutionStep::CreatePr(create);
+        let output = format_step_for_dry_run(&step, "origin");
+        assert!(output.contains("[draft]"));
+    }
+
+    #[test]
+    fn test_format_step_update_base() {
+        let bm = make_bookmark("feat-b");
+        let update = PrBaseUpdate {
+            bookmark: bm,
+            current_base: "main".to_string(),
+            expected_base: "feat-a".to_string(),
+            pr: make_pr(42, "feat-b"),
+        };
+        let step = ExecutionStep::UpdateBase(update);
+        let output = format_step_for_dry_run(&step, "origin");
+        assert_eq!(output, "  → update feat-b (PR #42) main → feat-a");
+    }
+
+    #[test]
+    fn test_format_step_publish() {
+        let pr = make_pr(99, "feat-a");
+        let step = ExecutionStep::PublishPr(pr);
+        let output = format_step_for_dry_run(&step, "origin");
+        assert_eq!(output, "  → publish PR #99 (feat-a)");
+    }
+
+    // === Stack comment tests ===
+
     #[test]
     fn test_build_stack_comment_data() {
-        use crate::types::NarrowedBookmarkSegment;
-
         let plan = SubmissionPlan {
             segments: vec![
                 NarrowedBookmarkSegment {
@@ -402,10 +595,8 @@ mod tests {
                     changes: vec![],
                 },
             ],
-            bookmarks_needing_push: vec![],
-            prs_to_create: vec![],
-            prs_to_update_base: vec![],
-            prs_to_publish: vec![],
+            constraints: vec![],
+            execution_steps: vec![],
             existing_prs: HashMap::new(),
             remote: "origin".to_string(),
             default_branch: "main".to_string(),
@@ -426,17 +617,118 @@ mod tests {
     }
 
     #[test]
-    fn test_submission_result_default() {
-        let result = SubmissionResult {
-            success: true,
-            created_prs: vec![],
-            updated_prs: vec![],
-            pushed_bookmarks: vec![],
-            errors: vec![],
+    fn test_build_stack_comment_data_filters_missing_prs() {
+        let plan = SubmissionPlan {
+            segments: vec![
+                NarrowedBookmarkSegment {
+                    bookmark: make_bookmark("feat-a"),
+                    changes: vec![],
+                },
+                NarrowedBookmarkSegment {
+                    bookmark: make_bookmark("feat-b"),
+                    changes: vec![],
+                },
+            ],
+            constraints: vec![],
+            execution_steps: vec![],
+            existing_prs: HashMap::new(),
+            remote: "origin".to_string(),
+            default_branch: "main".to_string(),
         };
 
-        assert!(result.success);
-        assert!(result.created_prs.is_empty());
-        assert!(result.updated_prs.is_empty());
+        // Only feat-a has a PR
+        let mut bookmark_to_pr = HashMap::new();
+        bookmark_to_pr.insert("feat-a".to_string(), make_pr(1, "feat-a"));
+
+        let data = build_stack_comment_data(&plan, &bookmark_to_pr);
+
+        assert_eq!(data.stack.len(), 1);
+        assert_eq!(data.stack[0].bookmark_name, "feat-a");
+    }
+
+    #[test]
+    fn test_format_stack_comment_marks_current() {
+        let data = StackCommentData {
+            version: 0,
+            stack: vec![
+                StackItem {
+                    bookmark_name: "feat-a".to_string(),
+                    pr_url: "https://example.com/1".to_string(),
+                    pr_number: 1,
+                },
+                StackItem {
+                    bookmark_name: "feat-b".to_string(),
+                    pr_url: "https://example.com/2".to_string(),
+                    pr_number: 2,
+                },
+            ],
+        };
+
+        // Format for PR #2 (index 1)
+        let body = format_stack_comment(&data, 1).unwrap();
+        assert!(body.contains(&format!("#{} {STACK_COMMENT_THIS_PR}", 2)));
+        assert!(!body.contains(&format!("#{} {STACK_COMMENT_THIS_PR}", 1)));
+    }
+
+    #[test]
+    fn test_format_stack_comment_contains_prefix() {
+        let data = StackCommentData {
+            version: 0,
+            stack: vec![StackItem {
+                bookmark_name: "feat-a".to_string(),
+                pr_url: "https://example.com/1".to_string(),
+                pr_number: 1,
+            }],
+        };
+
+        let body = format_stack_comment(&data, 0).unwrap();
+        assert!(body.contains(COMMENT_DATA_PREFIX));
+        assert!(body.contains(COMMENT_DATA_POSTFIX));
+    }
+
+    // === Plan helper tests ===
+
+    #[test]
+    fn test_plan_is_empty() {
+        let plan = SubmissionPlan {
+            segments: vec![],
+            constraints: vec![],
+            execution_steps: vec![],
+            existing_prs: HashMap::new(),
+            remote: "origin".to_string(),
+            default_branch: "main".to_string(),
+        };
+
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn test_plan_counts() {
+        let bm = make_bookmark("feat-a");
+        let plan = SubmissionPlan {
+            segments: vec![NarrowedBookmarkSegment {
+                bookmark: bm.clone(),
+                changes: vec![],
+            }],
+            constraints: vec![],
+            execution_steps: vec![
+                ExecutionStep::Push(bm.clone()),
+                ExecutionStep::CreatePr(PrToCreate {
+                    bookmark: bm,
+                    base_branch: "main".to_string(),
+                    title: "Add feat-a".to_string(),
+                    draft: false,
+                }),
+            ],
+            existing_prs: HashMap::new(),
+            remote: "origin".to_string(),
+            default_branch: "main".to_string(),
+        };
+
+        assert!(!plan.is_empty());
+        assert_eq!(plan.count_pushes(), 1);
+        assert_eq!(plan.count_creates(), 1);
+        assert_eq!(plan.count_updates(), 0);
+        assert_eq!(plan.count_publishes(), 0);
     }
 }

--- a/src/submit/mod.rs
+++ b/src/submit/mod.rs
@@ -23,5 +23,8 @@ pub use execute::{
     COMMENT_DATA_POSTFIX, COMMENT_DATA_PREFIX, StackCommentData, StackItem,
     build_stack_comment_data,
 };
-pub use plan::{PrBaseUpdate, PrToCreate, SubmissionPlan, create_submission_plan};
+pub use plan::{
+    ExecutionConstraint, ExecutionStep, PrBaseUpdate, PrToCreate, SubmissionPlan,
+    create_submission_plan,
+};
 pub use progress::{NoopProgress, Phase, ProgressCallback, PushStatus};

--- a/src/submit/plan.rs
+++ b/src/submit/plan.rs
@@ -2,12 +2,13 @@
 //!
 //! Determines what operations need to be performed to submit a stack.
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::platform::PlatformService;
 use crate::submit::SubmissionAnalysis;
 use crate::submit::analysis::{generate_pr_title, get_base_branch};
 use crate::types::{Bookmark, NarrowedBookmarkSegment, PullRequest};
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 /// Information about a PR that needs to be created
 #[derive(Debug, Clone)]
@@ -35,25 +36,281 @@ pub struct PrBaseUpdate {
     pub pr: PullRequest,
 }
 
+/// Ordered execution step for a submission plan
+#[derive(Debug, Clone)]
+pub enum ExecutionStep {
+    /// Push bookmark to remote
+    Push(Bookmark),
+    /// Update PR base branch
+    UpdateBase(PrBaseUpdate),
+    /// Create a new PR
+    CreatePr(PrToCreate),
+    /// Publish a draft PR
+    PublishPr(PullRequest),
+}
+
+impl ExecutionStep {
+    /// Get the bookmark name for this step
+    pub fn bookmark_name(&self) -> &str {
+        match self {
+            Self::Push(bm) => &bm.name,
+            Self::UpdateBase(update) => &update.bookmark.name,
+            Self::CreatePr(create) => &create.bookmark.name,
+            Self::PublishPr(pr) => &pr.head_ref,
+        }
+    }
+}
+
+impl std::fmt::Display for ExecutionStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Push(bm) => write!(f, "push {}", bm.name),
+            Self::UpdateBase(update) => write!(
+                f,
+                "update {} (PR #{}) {} → {}",
+                update.bookmark.name, update.pr.number, update.current_base, update.expected_base
+            ),
+            Self::CreatePr(create) => {
+                write!(f, "create PR {} → {} ({})", create.bookmark.name, create.base_branch, create.title)?;
+                if create.draft {
+                    write!(f, " [draft]")?;
+                }
+                Ok(())
+            }
+            Self::PublishPr(pr) => write!(f, "publish PR #{} ({})", pr.number, pr.head_ref),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Typed constraint system for dependency-aware scheduling
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Typed reference to a Push operation by bookmark name.
+/// Distinct from [`UpdateRef`]/[`CreateRef`] to prevent mixing constraint endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PushRef(pub String);
+
+/// Typed reference to an `UpdateBase` operation by bookmark name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UpdateRef(pub String);
+
+/// Typed reference to a `CreatePr` operation by bookmark name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateRef(pub String);
+
+/// Dependency constraint between execution operations.
+///
+/// Each variant encodes a semantic relationship between operations.
+/// Invalid pairings (e.g., `CreatePr` → `Push`) are unrepresentable at the type level.
+///
+/// Constraints may reference operations that don't exist in the current plan
+/// (e.g., a bookmark that's already synced has no `Push` node). Resolution
+/// returns `None` for such constraints, which is expected behavior.
+#[derive(Debug, Clone)]
+pub enum ExecutionConstraint {
+    /// Push parent branch before child branch.
+    /// Ensures commits are pushed in stack order (ancestors before descendants).
+    PushOrder {
+        /// Parent bookmark (pushed first)
+        parent: PushRef,
+        /// Child bookmark (pushed second)
+        child: PushRef,
+    },
+
+    /// Push new base branch before retargeting PR to it.
+    /// Can't retarget a PR to a branch that doesn't exist on remote yet.
+    PushBeforeRetarget {
+        /// Base branch to push
+        base: PushRef,
+        /// PR to retarget
+        pr: UpdateRef,
+    },
+
+    /// Retarget PR before pushing its old base (swap scenario).
+    /// When stack order changes and a PR's current base moves "below" it,
+    /// must retarget first to avoid platform rejection.
+    RetargetBeforePush {
+        /// PR to retarget first
+        pr: UpdateRef,
+        /// Old base to push after
+        old_base: PushRef,
+    },
+
+    /// Push branch before creating PR for it.
+    /// Branch must exist on remote before PR creation.
+    PushBeforeCreate {
+        /// Branch to push
+        push: PushRef,
+        /// PR to create
+        create: CreateRef,
+    },
+
+    /// Create parent PR before child PR.
+    /// Parent PR must exist so stack comments can reference its number/URL.
+    CreateOrder {
+        /// Parent PR (created first)
+        parent: CreateRef,
+        /// Child PR (created second)
+        child: CreateRef,
+    },
+}
+
+impl std::fmt::Display for ExecutionConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PushOrder { parent, child } => {
+                write!(f, "Push({}) → Push({})", parent.0, child.0)
+            }
+            Self::PushBeforeRetarget { base, pr } => {
+                write!(f, "Push({}) → UpdateBase({})", base.0, pr.0)
+            }
+            Self::RetargetBeforePush { pr, old_base } => {
+                write!(f, "UpdateBase({}) → Push({})", pr.0, old_base.0)
+            }
+            Self::PushBeforeCreate { push, create } => {
+                write!(f, "Push({}) → CreatePr({})", push.0, create.0)
+            }
+            Self::CreateOrder { parent, child } => {
+                write!(f, "CreatePr({}) → CreatePr({})", parent.0, child.0)
+            }
+        }
+    }
+}
+
+/// Opaque node index, only obtainable via [`NodeRegistry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct NodeIdx(usize);
+
+/// Registry mapping typed refs to node indices.
+/// Built during node creation, consumed during constraint resolution.
+#[derive(Debug, Default)]
+struct NodeRegistry {
+    push: HashMap<String, NodeIdx>,
+    update: HashMap<String, NodeIdx>,
+    create: HashMap<String, NodeIdx>,
+    publish: HashMap<String, NodeIdx>,
+}
+
+impl NodeRegistry {
+    fn register_push(&mut self, name: &str, idx: usize) {
+        self.push.insert(name.to_string(), NodeIdx(idx));
+    }
+
+    fn register_update(&mut self, name: &str, idx: usize) {
+        self.update.insert(name.to_string(), NodeIdx(idx));
+    }
+
+    fn register_create(&mut self, name: &str, idx: usize) {
+        self.create.insert(name.to_string(), NodeIdx(idx));
+    }
+
+    fn register_publish(&mut self, name: &str, idx: usize) {
+        self.publish.insert(name.to_string(), NodeIdx(idx));
+    }
+
+    fn len(&self) -> usize {
+        self.push.len() + self.update.len() + self.create.len() + self.publish.len()
+    }
+}
+
+impl ExecutionConstraint {
+    /// Resolve constraint to concrete `(from, to)` indices.
+    ///
+    /// Returns `None` if either endpoint doesn't exist in the registry.
+    /// This is expected when an operation isn't needed (e.g., already-synced bookmark).
+    fn resolve(&self, registry: &NodeRegistry) -> Option<(usize, usize)> {
+        match self {
+            Self::PushOrder { parent, child } => {
+                let from = registry.push.get(&parent.0)?;
+                let to = registry.push.get(&child.0)?;
+                Some((from.0, to.0))
+            }
+            Self::PushBeforeRetarget { base, pr } => {
+                let from = registry.push.get(&base.0)?;
+                let to = registry.update.get(&pr.0)?;
+                Some((from.0, to.0))
+            }
+            Self::RetargetBeforePush { pr, old_base } => {
+                let from = registry.update.get(&pr.0)?;
+                let to = registry.push.get(&old_base.0)?;
+                Some((from.0, to.0))
+            }
+            Self::PushBeforeCreate { push, create } => {
+                let from = registry.push.get(&push.0)?;
+                let to = registry.create.get(&create.0)?;
+                Some((from.0, to.0))
+            }
+            Self::CreateOrder { parent, child } => {
+                let from = registry.create.get(&parent.0)?;
+                let to = registry.create.get(&child.0)?;
+                Some((from.0, to.0))
+            }
+        }
+    }
+}
+
+/// Internal node for dependency-aware scheduling
+#[derive(Debug, Clone)]
+struct ExecutionNode {
+    step: ExecutionStep,
+    order: usize,
+}
+
 /// Submission plan
 #[derive(Debug, Clone)]
 pub struct SubmissionPlan {
-    /// Segments to submit
+    /// Segments to submit (used for stack comment generation)
     pub segments: Vec<NarrowedBookmarkSegment>,
-    /// Bookmarks that need to be pushed to remote
-    pub bookmarks_needing_push: Vec<Bookmark>,
-    /// Bookmarks that need new PRs created
-    pub prs_to_create: Vec<PrToCreate>,
-    /// Bookmarks with existing PRs that need base updated
-    pub prs_to_update_base: Vec<PrBaseUpdate>,
-    /// Draft PRs that should be published
-    pub prs_to_publish: Vec<PullRequest>,
+    /// Dependency constraints between operations (for debugging/dry-run display)
+    pub constraints: Vec<ExecutionConstraint>,
+    /// Ordered execution steps
+    pub execution_steps: Vec<ExecutionStep>,
     /// Existing PRs by bookmark name
     pub existing_prs: HashMap<String, PullRequest>,
     /// Remote name to push to
     pub remote: String,
     /// Default branch name (main/master)
     pub default_branch: String,
+}
+
+impl SubmissionPlan {
+    /// Check if there's nothing to do
+    pub fn is_empty(&self) -> bool {
+        self.execution_steps.is_empty()
+    }
+
+    /// Count push steps
+    pub fn count_pushes(&self) -> usize {
+        self.execution_steps
+            .iter()
+            .filter(|s| matches!(s, ExecutionStep::Push(_)))
+            .count()
+    }
+
+    /// Count create PR steps
+    pub fn count_creates(&self) -> usize {
+        self.execution_steps
+            .iter()
+            .filter(|s| matches!(s, ExecutionStep::CreatePr(_)))
+            .count()
+    }
+
+    /// Count update base steps
+    pub fn count_updates(&self) -> usize {
+        self.execution_steps
+            .iter()
+            .filter(|s| matches!(s, ExecutionStep::UpdateBase(_)))
+            .count()
+    }
+
+    /// Count publish steps
+    pub fn count_publishes(&self) -> usize {
+        self.execution_steps
+            .iter()
+            .filter(|s| matches!(s, ExecutionStep::PublishPr(_)))
+            .count()
+    }
 }
 
 /// Create a submission plan
@@ -79,7 +336,7 @@ pub async fn create_submission_plan(
         }
     }
 
-    // Determine what needs to happen
+    // Collect raw operations (unordered)
     let mut bookmarks_needing_push = Vec::new();
     let mut prs_to_create = Vec::new();
     let mut prs_to_update_base = Vec::new();
@@ -117,22 +374,301 @@ pub async fn create_submission_plan(
         }
     }
 
+    // Build ordered execution steps
+    let (constraints, execution_steps) = build_execution_steps(
+        segments,
+        &bookmarks_needing_push,
+        &prs_to_update_base,
+        &prs_to_create,
+        &[], // prs_to_publish populated by CLI layer via apply_plan_options
+    )?;
+
     Ok(SubmissionPlan {
         segments: segments.clone(),
-        bookmarks_needing_push,
-        prs_to_create,
-        prs_to_update_base,
-        prs_to_publish: Vec::new(),
+        constraints,
+        execution_steps,
         existing_prs,
         remote: remote.to_string(),
         default_branch: default_branch.to_string(),
     })
 }
 
+/// Build dependency-ordered execution steps.
+///
+/// Returns both the constraints (for debugging/display) and the sorted execution steps.
+fn build_execution_steps(
+    segments: &[NarrowedBookmarkSegment],
+    bookmarks_needing_push: &[Bookmark],
+    prs_to_update_base: &[PrBaseUpdate],
+    prs_to_create: &[PrToCreate],
+    prs_to_publish: &[PullRequest],
+) -> Result<(Vec<ExecutionConstraint>, Vec<ExecutionStep>)> {
+    let stack_index = build_stack_index(segments);
+
+    // Phase 1: Collect semantic constraints (declarative, no indices)
+    let constraints = collect_constraints(segments, prs_to_update_base, prs_to_create, &stack_index);
+
+    tracing::debug!(
+        constraint_count = constraints.len(),
+        "Collected execution constraints"
+    );
+
+    // Phase 2: Build nodes and registry
+    let (nodes, registry) = build_execution_nodes(
+        segments,
+        bookmarks_needing_push,
+        prs_to_update_base,
+        prs_to_create,
+        prs_to_publish,
+    );
+
+    // Phase 3: Resolve constraints to edges
+    let edges = resolve_constraints(&constraints, &registry);
+
+    // Phase 4: Topological sort
+    let steps = topo_sort_steps(&nodes, &edges)?;
+
+    Ok((constraints, steps))
+}
+
+/// Map bookmark name to stack position for relative ordering
+fn build_stack_index(segments: &[NarrowedBookmarkSegment]) -> HashMap<String, usize> {
+    segments
+        .iter()
+        .enumerate()
+        .map(|(idx, seg)| (seg.bookmark.name.clone(), idx))
+        .collect()
+}
+
+/// Collect all dependency constraints declaratively.
+///
+/// This phase creates typed constraints without resolving them to indices.
+/// Constraints may reference operations that won't exist in the final plan
+/// (e.g., already-synced bookmarks have no Push node); resolution handles this.
+fn collect_constraints(
+    segments: &[NarrowedBookmarkSegment],
+    prs_to_update_base: &[PrBaseUpdate],
+    prs_to_create: &[PrToCreate],
+    stack_index: &HashMap<String, usize>,
+) -> Vec<ExecutionConstraint> {
+    let mut constraints = Vec::new();
+
+    // Constraint: Push(parent) → Push(child) for stack order
+    for window in segments.windows(2) {
+        constraints.push(ExecutionConstraint::PushOrder {
+            parent: PushRef(window[0].bookmark.name.clone()),
+            child: PushRef(window[1].bookmark.name.clone()),
+        });
+    }
+
+    // Constraint: Push(expected_base) → UpdateBase(PR)
+    for update in prs_to_update_base {
+        constraints.push(ExecutionConstraint::PushBeforeRetarget {
+            base: PushRef(update.expected_base.clone()),
+            pr: UpdateRef(update.bookmark.name.clone()),
+        });
+    }
+
+    // Constraint: UpdateBase(PR) → Push(current_base) when swapping
+    for update in prs_to_update_base {
+        if update.expected_base != update.current_base {
+            let current_pos = stack_index.get(&update.current_base);
+            let bookmark_pos = stack_index.get(&update.bookmark.name);
+            if let (Some(&current_pos), Some(&bookmark_pos)) = (current_pos, bookmark_pos) {
+                if current_pos > bookmark_pos {
+                    // Current base is now below this bookmark - swap scenario
+                    constraints.push(ExecutionConstraint::RetargetBeforePush {
+                        pr: UpdateRef(update.bookmark.name.clone()),
+                        old_base: PushRef(update.current_base.clone()),
+                    });
+                }
+            }
+        }
+    }
+
+    // Constraint: Push(bookmark) → CreatePr(bookmark)
+    for create in prs_to_create {
+        constraints.push(ExecutionConstraint::PushBeforeCreate {
+            push: PushRef(create.bookmark.name.clone()),
+            create: CreateRef(create.bookmark.name.clone()),
+        });
+    }
+
+    // Constraint: CreatePr(parent) → CreatePr(child)
+    for window in segments.windows(2) {
+        constraints.push(ExecutionConstraint::CreateOrder {
+            parent: CreateRef(window[0].bookmark.name.clone()),
+            child: CreateRef(window[1].bookmark.name.clone()),
+        });
+    }
+
+    constraints
+}
+
+/// Build execution nodes for all operations
+fn build_execution_nodes(
+    segments: &[NarrowedBookmarkSegment],
+    bookmarks_needing_push: &[Bookmark],
+    prs_to_update_base: &[PrBaseUpdate],
+    prs_to_create: &[PrToCreate],
+    prs_to_publish: &[PullRequest],
+) -> (Vec<ExecutionNode>, NodeRegistry) {
+    let mut nodes = Vec::new();
+    let mut order = 0usize;
+    let mut registry = NodeRegistry::default();
+
+    // Build push set for O(1) lookup
+    let push_set: HashSet<_> = bookmarks_needing_push.iter().map(|b| &b.name).collect();
+
+    // Add push nodes in stack order
+    for seg in segments {
+        if push_set.contains(&seg.bookmark.name) {
+            let bookmark = bookmarks_needing_push
+                .iter()
+                .find(|b| b.name == seg.bookmark.name)
+                .unwrap()
+                .clone();
+            registry.register_push(&seg.bookmark.name, nodes.len());
+            nodes.push(ExecutionNode {
+                step: ExecutionStep::Push(bookmark),
+                order,
+            });
+            order += 1;
+        }
+    }
+
+    // Add any pushes not in segments (shouldn't happen, but be safe)
+    for bookmark in bookmarks_needing_push {
+        if !registry.push.contains_key(&bookmark.name) {
+            registry.register_push(&bookmark.name, nodes.len());
+            nodes.push(ExecutionNode {
+                step: ExecutionStep::Push(bookmark.clone()),
+                order,
+            });
+            order += 1;
+        }
+    }
+
+    // Add update base nodes
+    for update in prs_to_update_base {
+        registry.register_update(&update.bookmark.name, nodes.len());
+        nodes.push(ExecutionNode {
+            step: ExecutionStep::UpdateBase(update.clone()),
+            order,
+        });
+        order += 1;
+    }
+
+    // Add create PR nodes (in stack order for proper base dependencies)
+    let create_set: HashSet<_> = prs_to_create.iter().map(|c| &c.bookmark.name).collect();
+    for seg in segments {
+        if create_set.contains(&seg.bookmark.name) {
+            let create = prs_to_create
+                .iter()
+                .find(|c| c.bookmark.name == seg.bookmark.name)
+                .unwrap()
+                .clone();
+            registry.register_create(&seg.bookmark.name, nodes.len());
+            nodes.push(ExecutionNode {
+                step: ExecutionStep::CreatePr(create),
+                order,
+            });
+            order += 1;
+        }
+    }
+
+    // Add publish nodes
+    for pr in prs_to_publish {
+        registry.register_publish(&pr.head_ref, nodes.len());
+        nodes.push(ExecutionNode {
+            step: ExecutionStep::PublishPr(pr.clone()),
+            order,
+        });
+        order += 1;
+    }
+
+    (nodes, registry)
+}
+
+/// Resolve constraints to adjacency list edges.
+///
+/// Constraints that reference non-existent nodes are silently skipped.
+/// This is expected: e.g., a Push constraint for an already-synced bookmark.
+fn resolve_constraints(constraints: &[ExecutionConstraint], registry: &NodeRegistry) -> Vec<Vec<usize>> {
+    let mut edges = vec![Vec::new(); registry.len()];
+
+    for constraint in constraints {
+        if let Some((from, to)) = constraint.resolve(registry) {
+            if !edges[from].contains(&to) {
+                edges[from].push(to);
+                tracing::trace!(%constraint, from, to, "Resolved constraint to edge");
+            }
+        } else {
+            tracing::trace!(%constraint, "Constraint skipped (endpoint not in plan)");
+        }
+    }
+
+    edges
+}
+
+/// Topologically sort nodes respecting dependencies
+fn topo_sort_steps(nodes: &[ExecutionNode], edges: &[Vec<usize>]) -> Result<Vec<ExecutionStep>> {
+    // Kahn's algorithm with heap for stable ordering
+    let mut indegree = vec![0usize; nodes.len()];
+    for edge_list in edges {
+        for &to in edge_list {
+            indegree[to] += 1;
+        }
+    }
+
+    // Use min-heap by (order, idx) for deterministic output
+    let mut ready = BinaryHeap::new();
+    for (idx, node) in nodes.iter().enumerate() {
+        if indegree[idx] == 0 {
+            ready.push(Reverse((node.order, idx)));
+        }
+    }
+
+    let mut sorted = Vec::with_capacity(nodes.len());
+    while let Some(Reverse((_order, idx))) = ready.pop() {
+        sorted.push(idx);
+        for &to in &edges[idx] {
+            indegree[to] -= 1;
+            if indegree[to] == 0 {
+                ready.push(Reverse((nodes[to].order, to)));
+            }
+        }
+    }
+
+    if sorted.len() != nodes.len() {
+        // Collect nodes stuck in the cycle (indegree > 0 means couldn't be scheduled)
+        let cycle_nodes: Vec<String> = nodes
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| indegree[*idx] > 0)
+            .map(|(_, node)| format!("{}", node.step))
+            .collect();
+
+        tracing::error!(
+            cycle_nodes = ?cycle_nodes,
+            "Scheduler cycle detected - this is a bug in jj-ryu"
+        );
+
+        return Err(Error::SchedulerCycle {
+            message: "Dependency cycle in execution plan - this is a bug in jj-ryu, please report it".to_string(),
+            cycle_nodes,
+        });
+    }
+
+    Ok(sorted
+        .into_iter()
+        .map(|idx| nodes[idx].step.clone())
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::NarrowedBookmarkSegment;
 
     fn make_bookmark(name: &str, has_remote: bool, is_synced: bool) -> Bookmark {
         Bookmark {
@@ -144,17 +680,60 @@ mod tests {
         }
     }
 
+    fn make_segment(name: &str) -> NarrowedBookmarkSegment {
+        NarrowedBookmarkSegment {
+            bookmark: make_bookmark(name, false, false),
+            changes: vec![],
+        }
+    }
+
+    fn make_pr(number: u64, bookmark: &str, base: &str) -> PullRequest {
+        PullRequest {
+            number,
+            html_url: format!("https://github.com/test/test/pull/{number}"),
+            base_ref: base.to_string(),
+            head_ref: bookmark.to_string(),
+            title: format!("PR for {bookmark}"),
+            node_id: Some(format!("PR_node_{number}")),
+            is_draft: false,
+        }
+    }
+
+    fn make_update(
+        bookmark: &Bookmark,
+        current_base: &str,
+        expected_base: &str,
+        pr_number: u64,
+    ) -> PrBaseUpdate {
+        PrBaseUpdate {
+            bookmark: bookmark.clone(),
+            current_base: current_base.to_string(),
+            expected_base: expected_base.to_string(),
+            pr: make_pr(pr_number, &bookmark.name, current_base),
+        }
+    }
+
+    fn make_create(bookmark: &Bookmark, base_branch: &str) -> PrToCreate {
+        PrToCreate {
+            bookmark: bookmark.clone(),
+            base_branch: base_branch.to_string(),
+            title: format!("Add {}", bookmark.name),
+            draft: false,
+        }
+    }
+
+    fn find_step_index(steps: &[ExecutionStep], predicate: impl Fn(&ExecutionStep) -> bool) -> Option<usize> {
+        steps.iter().position(predicate)
+    }
+
     #[test]
     fn test_bookmark_needs_push() {
-        // No remote tracking
         let bm1 = make_bookmark("feat-a", false, false);
         assert!(!bm1.has_remote || !bm1.is_synced);
 
-        // Has remote but not synced
         let bm2 = make_bookmark("feat-b", true, false);
         assert!(!bm2.has_remote || !bm2.is_synced);
 
-        // Fully synced - doesn't need push
         let bm3 = make_bookmark("feat-c", true, true);
         assert!(bm3.has_remote && bm3.is_synced);
     }
@@ -175,30 +754,111 @@ mod tests {
     }
 
     #[test]
-    fn test_submission_plan_structure() {
+    fn test_execution_steps_simple_push_order() {
+        let segments = vec![make_segment("a"), make_segment("b")];
+        let pushes = vec![
+            make_bookmark("a", false, false),
+            make_bookmark("b", false, false),
+        ];
+
+        let (_constraints, steps) = build_execution_steps(&segments, &pushes, &[], &[], &[]).unwrap();
+
+        let push_a = find_step_index(&steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "a"));
+        let push_b = find_step_index(&steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "b"));
+
+        assert!(push_a.unwrap() < push_b.unwrap(), "pushes should follow stack order");
+    }
+
+    #[test]
+    fn test_execution_steps_push_before_create() {
+        let bm_a = make_bookmark("a", false, false);
+        let segments = vec![make_segment("a")];
+        let pushes = vec![bm_a.clone()];
+        let creates = vec![make_create(&bm_a, "main")];
+
+        let (_constraints, steps) = build_execution_steps(&segments, &pushes, &[], &creates, &[]).unwrap();
+
+        let push_a = find_step_index(&steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "a")).unwrap();
+        let create_a = find_step_index(&steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "a")).unwrap();
+
+        assert!(push_a < create_a, "push must happen before create");
+    }
+
+    #[test]
+    fn test_execution_steps_create_order_follows_stack() {
+        let bm_a = make_bookmark("a", false, false);
+        let bm_b = make_bookmark("b", false, false);
+        let segments = vec![make_segment("a"), make_segment("b")];
+        let pushes = vec![bm_a.clone(), bm_b.clone()];
+        let creates = vec![make_create(&bm_a, "main"), make_create(&bm_b, "a")];
+
+        let (_constraints, steps) = build_execution_steps(&segments, &pushes, &[], &creates, &[]).unwrap();
+
+        let create_a = find_step_index(&steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "a")).unwrap();
+        let create_b = find_step_index(&steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "b")).unwrap();
+
+        assert!(create_a < create_b, "creates should follow stack order");
+    }
+
+    #[test]
+    fn test_execution_steps_swap_order() {
+        // Scenario: Stack was A -> B, now B -> A (swapped)
+        let bm_a = make_bookmark("a", false, false);
+        let bm_b = make_bookmark("b", false, false);
+
+        // New stack order: B is root, A is leaf
+        let segments = vec![make_segment("b"), make_segment("a")];
+        let pushes = vec![bm_a.clone(), bm_b.clone()];
+        let updates = vec![
+            make_update(&bm_b, "a", "main", 2), // B was on A, now on main
+            make_update(&bm_a, "main", "b", 1), // A was on main, now on B
+        ];
+
+        let (_constraints, steps) = build_execution_steps(&segments, &pushes, &updates, &[], &[]).unwrap();
+
+        let retarget_b = find_step_index(&steps, |s| matches!(s, ExecutionStep::UpdateBase(u) if u.bookmark.name == "b")).unwrap();
+        let push_a = find_step_index(&steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "a")).unwrap();
+        let push_b = find_step_index(&steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "b")).unwrap();
+
+        assert!(retarget_b < push_a, "b must move off a before pushing a");
+        assert!(push_b < push_a, "push order should follow new stack (b before a)");
+    }
+
+    #[test]
+    fn test_plan_is_empty() {
         let plan = SubmissionPlan {
-            segments: vec![NarrowedBookmarkSegment {
-                bookmark: make_bookmark("feat-a", false, false),
-                changes: vec![],
-            }],
-            bookmarks_needing_push: vec![make_bookmark("feat-a", false, false)],
-            prs_to_create: vec![PrToCreate {
-                bookmark: make_bookmark("feat-a", false, false),
-                base_branch: "main".to_string(),
-                title: "Test".to_string(),
-                draft: false,
-            }],
-            prs_to_update_base: vec![],
-            prs_to_publish: vec![],
+            segments: vec![],
+            constraints: vec![],
+            execution_steps: vec![],
             existing_prs: HashMap::new(),
             remote: "origin".to_string(),
             default_branch: "main".to_string(),
         };
 
-        assert_eq!(plan.segments.len(), 1);
-        assert_eq!(plan.bookmarks_needing_push.len(), 1);
-        assert_eq!(plan.prs_to_create.len(), 1);
-        assert!(plan.prs_to_update_base.is_empty());
-        assert!(plan.prs_to_publish.is_empty());
+        assert!(plan.is_empty());
+        assert_eq!(plan.count_pushes(), 0);
+        assert_eq!(plan.count_creates(), 0);
+    }
+
+    #[test]
+    fn test_plan_counts() {
+        let bm = make_bookmark("a", false, false);
+        let plan = SubmissionPlan {
+            segments: vec![make_segment("a")],
+            constraints: vec![],
+            execution_steps: vec![
+                ExecutionStep::Push(bm.clone()),
+                ExecutionStep::CreatePr(make_create(&bm, "main")),
+            ],
+            existing_prs: HashMap::new(),
+            remote: "origin".to_string(),
+            default_branch: "main".to_string(),
+        };
+
+        assert!(!plan.is_empty());
+        assert_eq!(plan.count_pushes(), 1);
+        assert_eq!(plan.count_creates(), 1);
+        assert_eq!(plan.count_updates(), 0);
+        assert_eq!(plan.count_publishes(), 0);
     }
 }

--- a/src/submit/progress.rs
+++ b/src/submit/progress.rs
@@ -14,18 +14,24 @@ pub enum Phase {
     Analyzing,
     /// Planning what to submit
     Planning,
-    /// Pushing bookmarks to remote
-    Pushing,
-    /// Creating new PRs
-    CreatingPrs,
-    /// Updating existing PR base branches
-    UpdatingPrs,
-    /// Publishing draft PRs
-    PublishingPrs,
+    /// Executing submission operations (push, create, update, publish)
+    Executing,
     /// Adding/updating stack comments
     AddingComments,
     /// Submission complete
     Complete,
+}
+
+impl std::fmt::Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Analyzing => write!(f, "Analyzing"),
+            Self::Planning => write!(f, "Planning"),
+            Self::Executing => write!(f, "Executing"),
+            Self::AddingComments => write!(f, "Updating stack comments"),
+            Self::Complete => write!(f, "Done"),
+        }
+    }
 }
 
 /// Push operation status
@@ -39,6 +45,17 @@ pub enum PushStatus {
     AlreadySynced,
     /// Push failed with error message
     Failed(String),
+}
+
+impl std::fmt::Display for PushStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Started => write!(f, "started"),
+            Self::Success => write!(f, "success"),
+            Self::AlreadySynced => write!(f, "already synced"),
+            Self::Failed(msg) => write!(f, "failed: {msg}"),
+        }
+    }
 }
 
 /// Progress callback trait

--- a/src/types.rs
+++ b/src/types.rs
@@ -138,6 +138,15 @@ pub enum Platform {
     GitLab,
 }
 
+impl std::fmt::Display for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GitHub => write!(f, "GitHub"),
+            Self::GitLab => write!(f, "GitLab"),
+        }
+    }
+}
+
 /// Platform configuration
 #[derive(Debug, Clone)]
 pub struct PlatformConfig {

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -78,6 +78,19 @@ pub fn make_pr(number: u64, head: &str, base: &str) -> PullRequest {
     }
 }
 
+/// Create a draft pull request
+pub fn make_pr_draft(number: u64, head: &str, base: &str) -> PullRequest {
+    PullRequest {
+        number,
+        html_url: format!("https://github.com/test/repo/pull/{number}"),
+        base_ref: base.to_string(),
+        head_ref: head.to_string(),
+        title: format!("PR for {head}"),
+        node_id: Some(format!("PR_node_{number}")),
+        is_draft: true,
+    }
+}
+
 /// Create a PR comment
 pub fn make_pr_comment(id: u64, body: &str) -> PrComment {
     PrComment {

--- a/tests/execution_step_tests.rs
+++ b/tests/execution_step_tests.rs
@@ -1,0 +1,538 @@
+//! Integration tests for `ExecutionStep` model (RFC: Unified Execution Step Model)
+//!
+//! Tests the dependency-aware topological ordering of execution steps using
+//! real jj repositories via `TempJjRepo`.
+
+mod common;
+
+use common::{MockPlatformService, TempJjRepo, github_config, make_pr, make_pr_draft};
+use jj_ryu::graph::build_change_graph;
+use jj_ryu::submit::{ExecutionStep, analyze_submission, create_submission_plan};
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Find the index of a step matching a predicate
+fn find_step_index(steps: &[ExecutionStep], predicate: impl Fn(&ExecutionStep) -> bool) -> Option<usize> {
+    steps.iter().position(predicate)
+}
+
+/// Assert step A comes before step B in the execution order
+fn assert_step_order(steps: &[ExecutionStep], description: &str, idx_a: usize, idx_b: usize) {
+    assert!(
+        idx_a < idx_b,
+        "{description}: expected step at index {idx_a} before step at index {idx_b}, \
+         but got order {:?}",
+        steps
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+    );
+}
+
+// =============================================================================
+// Stack Swap Ordering Tests (RFC §Problem Statement - Critical)
+// =============================================================================
+
+/// Test: When stack changes from A→B to B→A, UpdateBase(B) must come before Push(A)
+///
+/// This is the critical swap scenario that motivated the RFC. Without proper
+/// ordering, GitHub/GitLab would reject the base change due to branch history conflicts.
+#[tokio::test]
+async fn test_swap_scenario_retarget_before_push() {
+    // Setup: Create stack A→B (A is root, B is leaf)
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B")]);
+
+    // Swap the stack: rebase B before A, making order B→A
+    repo.rebase_before("feat-b", "feat-a");
+
+    // Now the stack is B→A in the jj repo
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+
+    // Analyze submitting A (the new leaf)
+    let analysis = analyze_submission(&graph, "feat-a").expect("analyze");
+
+    // Verify the analysis reflects the new order: B is root, A is leaf
+    assert_eq!(analysis.segments.len(), 2);
+    assert_eq!(analysis.segments[0].bookmark.name, "feat-b"); // root
+    assert_eq!(analysis.segments[1].bookmark.name, "feat-a"); // leaf
+
+    // Setup mock: Both PRs exist with OLD bases (before swap)
+    let mock = MockPlatformService::with_config(github_config());
+    mock.set_find_pr_response("feat-a", Some(make_pr(1, "feat-a", "main"))); // Was root, now should be on B
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "feat-a"))); // Was on A, now should be on main
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // Verify we have the expected operations
+    assert!(plan.count_updates() >= 1, "should have base updates for swapped PRs");
+    assert!(plan.count_pushes() >= 1, "should have pushes for changed branches");
+
+    // Critical assertion: UpdateBase operations must happen at correct time relative to pushes
+    // B's PR needs to be retargeted from feat-a to main BEFORE we push the new A
+    // (because A will have different history after the swap)
+    let steps = &plan.execution_steps;
+
+    // Find UpdateBase for B (changing from feat-a to main)
+    let update_b_idx = find_step_index(steps, |s| {
+        matches!(s, ExecutionStep::UpdateBase(u) if u.bookmark.name == "feat-b")
+    });
+
+    // Find Push for A
+    let push_a_idx = find_step_index(steps, |s| {
+        matches!(s, ExecutionStep::Push(b) if b.name == "feat-a")
+    });
+
+    // If B had A as its base and we're swapping, B's retarget should happen
+    // This test verifies the constraint system handles the swap correctly
+    if let (Some(update_idx), Some(push_idx)) = (update_b_idx, push_a_idx) {
+        // The RFC specifies: RetargetBeforePush when current base moves "below"
+        // B's current_base was "feat-a", B is now root (pos 0), A is leaf (pos 1)
+        // So current_base (feat-a) position (1) > bookmark position (0) - swap scenario!
+        assert_step_order(
+            steps,
+            "UpdateBase(B) must come before Push(A) in swap scenario",
+            update_idx,
+            push_idx,
+        );
+    }
+}
+
+/// Test: Three-level stack with middle element becoming root
+#[tokio::test]
+async fn test_three_level_swap_middle_to_root() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B"), ("feat-c", "Add C")]);
+
+    // Move B to be the root (before A)
+    repo.rebase_before("feat-b", "feat-a");
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+
+    // Submit from C (should include B→A→C or similar reordered stack)
+    let analysis = analyze_submission(&graph, "feat-c").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // All PRs exist with old bases
+    mock.set_find_pr_response("feat-a", Some(make_pr(1, "feat-a", "main")));
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "feat-a")));
+    mock.set_find_pr_response("feat-c", Some(make_pr(3, "feat-c", "feat-b")));
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // Should have operations to fix the base mismatches
+    // The exact operations depend on how jj rebase affects the graph
+    assert!(!plan.is_empty(), "plan should have operations after swap");
+}
+
+// =============================================================================
+// Constraint Resolution Tests (RFC §Three-Phase Execution)
+// =============================================================================
+
+/// Test: Push operations follow stack order (parent before child)
+#[tokio::test]
+async fn test_push_order_follows_stack_structure() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[
+        ("feat-a", "Add A"),
+        ("feat-b", "Add B"),
+        ("feat-c", "Add C"),
+        ("feat-d", "Add D"),
+    ]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-d").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // No existing PRs - all need push and create
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    assert_eq!(plan.count_pushes(), 4, "all 4 bookmarks need push");
+
+    let steps = &plan.execution_steps;
+    let push_a = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-a")).unwrap();
+    let push_b = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-b")).unwrap();
+    let push_c = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-c")).unwrap();
+    let push_d = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-d")).unwrap();
+
+    assert_step_order(steps, "Push(A) before Push(B)", push_a, push_b);
+    assert_step_order(steps, "Push(B) before Push(C)", push_b, push_c);
+    assert_step_order(steps, "Push(C) before Push(D)", push_c, push_d);
+}
+
+/// Test: `CreatePr` operations follow stack order for comment linking
+#[tokio::test]
+async fn test_create_order_respects_stack_for_comment_linking() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B"), ("feat-c", "Add C")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-c").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // No existing PRs
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    assert_eq!(plan.count_creates(), 3);
+
+    let steps = &plan.execution_steps;
+    let create_a = find_step_index(steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "feat-a")).unwrap();
+    let create_b = find_step_index(steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "feat-b")).unwrap();
+    let create_c = find_step_index(steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "feat-c")).unwrap();
+
+    assert_step_order(steps, "CreatePr(A) before CreatePr(B)", create_a, create_b);
+    assert_step_order(steps, "CreatePr(B) before CreatePr(C)", create_b, create_c);
+}
+
+/// Test: Push must happen before `CreatePr` for the same bookmark
+#[tokio::test]
+async fn test_push_before_create_constraint() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-a").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    assert_eq!(plan.count_pushes(), 1);
+    assert_eq!(plan.count_creates(), 1);
+
+    let steps = &plan.execution_steps;
+    let push_a = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-a")).unwrap();
+    let create_a = find_step_index(steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "feat-a")).unwrap();
+
+    assert_step_order(steps, "Push(A) before CreatePr(A)", push_a, create_a);
+}
+
+/// Test: Push base branch before retargeting PR to it
+#[tokio::test]
+async fn test_push_before_retarget_constraint() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-b").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // B's PR exists but has wrong base (main instead of feat-a)
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "main")));
+    // A has no PR yet
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // Should have: Push(A), Push(B), UpdateBase(B), CreatePr(A)
+    let steps = &plan.execution_steps;
+
+    let push_a = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-a"));
+    let update_b = find_step_index(steps, |s| matches!(s, ExecutionStep::UpdateBase(u) if u.bookmark.name == "feat-b"));
+
+    // Push(A) must happen before UpdateBase(B) because B's new base is A
+    if let (Some(push_idx), Some(update_idx)) = (push_a, update_b) {
+        assert_step_order(
+            steps,
+            "Push(A) before UpdateBase(B) - can't retarget to unpushed branch",
+            push_idx,
+            update_idx,
+        );
+    }
+}
+
+// =============================================================================
+// Mixed Operation Scenario Tests (RFC §Design)
+// =============================================================================
+
+/// Test: Partial existing PRs with mixed operations
+#[tokio::test]
+async fn test_partial_existing_prs_mixed_operations() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B"), ("feat-c", "Add C")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-c").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // A: PR exists with correct base (main)
+    mock.set_find_pr_response("feat-a", Some(make_pr(1, "feat-a", "main")));
+    // B: PR exists but wrong base (main instead of feat-a)
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "main")));
+    // C: No PR exists
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // Expected operations:
+    // - Push for all 3 (assuming not synced)
+    // - UpdateBase for B (fix base from main to feat-a)
+    // - CreatePr for C
+    assert_eq!(plan.count_updates(), 1, "B needs base update");
+    assert_eq!(plan.count_creates(), 1, "C needs PR creation");
+
+    // Verify ordering constraints
+    let steps = &plan.execution_steps;
+
+    // Push(A) should come before UpdateBase(B)
+    let push_a = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-a"));
+    let update_b = find_step_index(steps, |s| matches!(s, ExecutionStep::UpdateBase(u) if u.bookmark.name == "feat-b"));
+
+    if let (Some(push_idx), Some(update_idx)) = (push_a, update_b) {
+        assert_step_order(steps, "Push(A) before UpdateBase(B)", push_idx, update_idx);
+    }
+
+    // Push(C) should come before CreatePr(C)
+    let push_c = find_step_index(steps, |s| matches!(s, ExecutionStep::Push(b) if b.name == "feat-c"));
+    let create_c = find_step_index(steps, |s| matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == "feat-c"));
+
+    if let (Some(push_idx), Some(create_idx)) = (push_c, create_c) {
+        assert_step_order(steps, "Push(C) before CreatePr(C)", push_idx, create_idx);
+    }
+}
+
+/// Test: Plan with draft PR that needs publishing
+#[tokio::test]
+async fn test_draft_pr_in_stack() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-b").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // A: Draft PR exists
+    mock.set_find_pr_response("feat-a", Some(make_pr_draft(1, "feat-a", "main")));
+    // B: No PR
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // A's draft PR is tracked but not auto-published by planning
+    // (publishing is handled by CLI options)
+    assert_eq!(plan.existing_prs.len(), 1);
+    assert!(plan.existing_prs.get("feat-a").unwrap().is_draft);
+}
+
+// =============================================================================
+// Constraint Skipping Tests (RFC §NodeRegistry)
+// =============================================================================
+
+/// Test: Constraints gracefully skip when bookmarks are already synced
+#[tokio::test]
+async fn test_constraints_skip_synced_bookmarks() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-b").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // Both PRs exist with correct bases
+    mock.set_find_pr_response("feat-a", Some(make_pr(1, "feat-a", "main")));
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "feat-a")));
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // No creates or updates needed
+    assert_eq!(plan.count_creates(), 0);
+    assert_eq!(plan.count_updates(), 0);
+
+    // Plan should still be valid (constraints for CreateOrder should be skipped)
+    // since there are no CreatePr nodes to order
+}
+
+/// Test: All PRs exist with correct bases - minimal operations
+#[tokio::test]
+async fn test_all_prs_exist_correct_bases() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B"), ("feat-c", "Add C")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-c").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    mock.set_find_pr_response("feat-a", Some(make_pr(1, "feat-a", "main")));
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "feat-a")));
+    mock.set_find_pr_response("feat-c", Some(make_pr(3, "feat-c", "feat-b")));
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    assert_eq!(plan.count_creates(), 0, "no PRs to create");
+    assert_eq!(plan.count_updates(), 0, "no bases to update");
+    assert_eq!(plan.existing_prs.len(), 3, "all PRs tracked");
+}
+
+// =============================================================================
+// Deep Stack Tests
+// =============================================================================
+
+/// Test: 10-level deep stack maintains correct ordering
+#[tokio::test]
+async fn test_ten_level_stack_ordering() {
+    let repo = TempJjRepo::new();
+
+    let bookmarks: Vec<(&str, &str)> = (0..10)
+        .map(|i| {
+            // Leak strings to get static lifetime for the test
+            let name = Box::leak(format!("feat-{i}").into_boxed_str());
+            let msg = Box::leak(format!("Add feature {i}").into_boxed_str());
+            (name as &str, msg as &str)
+        })
+        .collect();
+
+    repo.build_stack(&bookmarks);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-9").expect("analyze");
+
+    assert_eq!(analysis.segments.len(), 10);
+
+    let mock = MockPlatformService::with_config(github_config());
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    assert_eq!(plan.count_pushes(), 10);
+    assert_eq!(plan.count_creates(), 10);
+
+    // Verify all pushes are in order
+    let steps = &plan.execution_steps;
+    let mut prev_push_idx = None;
+    for i in 0..10 {
+        let name = format!("feat-{i}");
+        let push_idx = find_step_index(steps, |s| {
+            matches!(s, ExecutionStep::Push(b) if b.name == name)
+        })
+        .unwrap_or_else(|| panic!("Push for {name} not found"));
+
+        if let Some(prev) = prev_push_idx {
+            assert!(
+                prev < push_idx,
+                "Push(feat-{}) at {prev} should come before Push({name}) at {push_idx}",
+                i - 1
+            );
+        }
+        prev_push_idx = Some(push_idx);
+    }
+
+    // Verify all creates are in order
+    let mut prev_create_idx = None;
+    for i in 0..10 {
+        let name = format!("feat-{i}");
+        let create_idx = find_step_index(steps, |s| {
+            matches!(s, ExecutionStep::CreatePr(c) if c.bookmark.name == name)
+        })
+        .unwrap_or_else(|| panic!("CreatePr for {name} not found"));
+
+        if let Some(prev) = prev_create_idx {
+            assert!(
+                prev < create_idx,
+                "CreatePr(feat-{}) at {prev} should come before CreatePr({name}) at {create_idx}",
+                i - 1
+            );
+        }
+        prev_create_idx = Some(create_idx);
+    }
+}
+
+// =============================================================================
+// ExecutionConstraint Display Tests
+// =============================================================================
+
+/// Test: `ExecutionConstraint` Display formatting is correct
+#[tokio::test]
+async fn test_constraint_display_formatting() {
+    let repo = TempJjRepo::new();
+    repo.build_stack(&[("feat-a", "Add A"), ("feat-b", "Add B")]);
+
+    let workspace = repo.workspace();
+    let graph = build_change_graph(&workspace).expect("build graph");
+    let analysis = analyze_submission(&graph, "feat-b").expect("analyze");
+
+    let mock = MockPlatformService::with_config(github_config());
+    // B has wrong base to generate UpdateBase constraint
+    mock.set_find_pr_response("feat-b", Some(make_pr(2, "feat-b", "main")));
+
+    let plan = create_submission_plan(&analysis, &mock, "origin", "main")
+        .await
+        .expect("create plan");
+
+    // Verify constraints are present and displayable
+    assert!(!plan.constraints.is_empty(), "should have constraints");
+
+    // Check that all constraints have valid Display output
+    for constraint in &plan.constraints {
+        let display = format!("{constraint}");
+        assert!(!display.is_empty(), "constraint display should not be empty");
+        assert!(
+            display.contains("→"),
+            "constraint display should contain arrow: {display}"
+        );
+    }
+}
+
+// =============================================================================
+// Cycle Detection Test
+// =============================================================================
+
+/// Test: `SchedulerCycle` error is properly detected
+///
+/// Note: This tests the error type exists and is properly formatted.
+/// Actually triggering a cycle requires manually constructing invalid constraints,
+/// which the type system prevents in normal usage.
+#[test]
+fn test_scheduler_cycle_error_format() {
+    use jj_ryu::error::Error;
+
+    let error = Error::SchedulerCycle {
+        message: "test cycle".to_string(),
+        cycle_nodes: vec!["push feat-a".to_string(), "update feat-b".to_string()],
+    };
+
+    let display = format!("{error}");
+    assert!(display.contains("scheduler cycle detected"));
+    assert!(display.contains("test cycle"));
+
+    // Verify the error contains cycle_nodes (for debugging)
+    match error {
+        Error::SchedulerCycle { cycle_nodes, .. } => {
+            assert_eq!(cycle_nodes.len(), 2);
+            assert!(cycle_nodes.contains(&"push feat-a".to_string()));
+        }
+        _ => panic!("wrong error variant"),
+    }
+}


### PR DESCRIPTION
When you have a stack like main <- A <- B, then you rebase so that you've got main <- B <- A, `ryu submit A` currently does this:

1. Push B
2. Push A
3. Retarget B -> main
4. Retarget A -> B

After step 2, A contains all the commits B contains, and B still targets A. GitHub then closes B as merged, because the retargets haven't taken place yet.

To fix this ryu needs to Retarget B -> main before it does Push A.

In order to do that, this PR combines the `Pushing` and `UpdatingPrs` phases into one, and calculates the correct dependency order between the steps. We can't just do `UpdatingPrs` before `Pushing` because GitHub rejects the retarget with "There are no new commits between base branch 'A' and head branch 'B'".

Honestly this feels like it's 50% of the way through a refactor from coarse phases -> individual steps, but I didn't want to rip out phases entirely without feedback first.

---

AI Disclosure: Initial implementation was done by Codex, taste/cleanup/validation done by me.
<details>
<summary>Session summary</summary>

(trying out a summary here, let me know if you'd rather see a raw transcript)

This implementation summary details the debugging, architectural planning, and execution of the fix for the PR auto-closure bug in `jj-ryu`.

### 1. Problem Identification & Diagnosis
**User Request:** Explain why swapping two branches (`a` and `b`) in a stack causes GitHub to auto-close the PR for the branch that becomes the new root.
**Agent Action:**
*   Analyzed `src/submit/execute.rs` and `src/submit/plan.rs`.
*   **Diagnosis:** The issue was an "all-push-then-all-retarget" execution order. When branches are swapped, pushing the new leaf (which contains the commits of the new root) while the old PR still targets the old parent causes GitHub to see the commits as "merged" and auto-close the PR.
*   **Proposed Correct Order:** Retarget the PR moving "off" its old parent first, push the rebased branches, then retarget the PR moving "onto" its new parent.

### 2. Reproduction via E2E Testing
**User Request:** Write a reproduction test in `tests/e2e_tests.rs`.
**Agent Action:**
*   Added `test_swap_stack_order_keeps_parent_pr_open` to the E2E suite.
*   The test builds a stack (A -> B), submits it, swaps the order (B -> A) via `jj rebase`, resubmits, and asserts that PR B remains open.
*   **Refinement:** Based on a follow-up request, the agent refactored `E2ERepo` to include a reusable `rebase_bookmark_onto` helper to keep the test code clean.

### 3. Architectural Design & Implementation Plan
**User Request:** Provide an implementation plan and identify ambiguities or adversarial cases.
**Agent Action:**
*   **Initial Thought:** Proposed a "safety mechanism" to temporarily retarget branches to the default branch (`main`).
*   **Critique (User & Agent):** Identified side effects of temporary retargeting: CI churn, reviewer pings, and permission issues.
*   **Final Strategy:** Adopted a **Dependency-Aware Scheduler**. Instead of a fixed order, the system would build a dependency graph of operations and use a topological sort to determine the safe sequence.
*   **Algorithmic Constraints:**
    1.  **Push before Retarget:** If a PR's `expected_base` is being pushed, that push must happen before the retarget.
    2.  **Retarget before Push (The Fix):** If a PR's `current_base` is being pushed and the new stack order inverts their relationship, the PR must be retargeted *off* the old base before that base is pushed.
    3.  **Preserve Stack Order:** Pushes should generally follow the root-to-leaf order for stability.

### 4. Implementation Phase
**User Request:** Implement the scheduler with unit tests.
**Agent Action:**
*   **Initial Implementation:** Built the scheduler inside `src/submit/execute.rs`.
*   **Course Correction (User):** The user pointed out this subverted the "Plan/Execute" split. Hoisted the logic into the Planning phase.
*   **Final Implementation:**
    *   Modified `SubmissionPlan` to include an ordered `Vec<ExecutionStep>`.
    *   Moved the `ExecutionStep` enum and scheduler logic to `src/submit/plan.rs`.
    *   Updated `create_submission_plan` to calculate the schedule at plan-time.
    *   Updated `execute_submission` to consume the pre-calculated steps.
    *   Updated `report_dry_run` to show the dependency-aware sequence during dry runs.

### 5. Code Quality & Refactoring
**User Request:** Address Clippy warnings and refactor the monolithic scheduler.
**Agent Action:**
*   **Refactoring:** Split the monolithic `build_execution_steps` function into four distinct parts:
    *   `build_stack_index`: Maps bookmarks to positions.
    *   `build_execution_nodes`: Creates nodes for every Push and UpdateBase operation.
    *   `build_execution_edges`: Encodes the dependency constraints.
    *   `topo_sort_steps`: Performs the topological sort using a `BinaryHeap` (Kahn's algorithm).
*   **Clippy Fixes:** Hoisted helper structs, converted value-passing to slices, and reduced function complexity.

### 6. Verification of Pre-existing Issues
**User Request:** Explain unrelated E2E test failures (`test_sync_after_merge`).
**Agent Action:**
*   Diagnosed that the failures were due to local `jj` state. Even after a remote merge, local bookmarks remained in the stack because `jj` does not auto-delete bookmarks on merge.
*   Confirmed these were pre-existing environmental/behavioral issues unrelated to the new scheduling logic.

### Final Result
*   **Architectural Change:** Submission is now driven by a dependency-aware execution schedule generated during the planning phase.
*   **Bug Fix:** Stack swaps no longer cause auto-closure on GitHub because PRs are moved off their old parents before those parents are updated with the inverted commits.
*   **Code Quality:** Scheduling logic is modular, tested against adversarial swap scenarios, and Clippy-clean.

</details>