### PR TITLE
feat: only sync out-of-sync bookmarks

### DIFF
--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -94,6 +94,17 @@ pub async fn run_sync(path: &Path, remote: Option<&str>, options: SyncOptions<'_
         graph.stacks.iter().collect()
     };
 
+    // Filter out stacks where all bookmarks are already synced
+    let stacks_to_sync: Vec<&BranchStack> = stacks_to_sync
+        .into_iter()
+        .filter(|stack| {
+            stack
+                .segments
+                .iter()
+                .any(|seg| seg.bookmarks.iter().any(|b| !b.has_remote || !b.is_synced))
+        })
+        .collect();
+
     if stacks_to_sync.is_empty() {
         println!("{}", "No stacks to sync".muted());
         return Ok(());


### PR DESCRIPTION
This fixes for me that it leaves comments on PRs from other people, since those are already marked as synced.

Before:
```
☸ default in main via  v22.21.1 via ❄️ impure on 󱗆 vyozunvx (ci-add-reset-db-job, main~1)
❯ ryu sync -c
⠏ ✓ Fetched from origin                                                                                                                                                                                                                 Sync plan:

Stack: ci-add-reset-db-job
  Already in sync

Stack: jeroen/nevo-fallback
  Already in sync

Stack: fix-missing-translations
  Already in sync

Proceed with sync? no
Aborted
```

After:
```
☸ default in main via  v22.21.1 via ❄️ impure on 󱗆 vyozunvx (ci-add-reset-db-job, main~1) took 33s
❯ ~/.cargo/bin/ryu sync -c
⠏ ✓ Fetched from origin
No stacks to sync
```