### PR TITLE
feat: Azure Devops integration (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img width="366" height="366" alt="image" src="https://github.com/user-attachments/assets/1691edfc-3b65-4f8d-b959-71ff21ff23e5" />
 
-Stacked PRs for [Jujutsu](https://jj-vcs.github.io/jj/latest/). Push bookmark stacks to GitHub and GitLab as chained pull requests.
+Stacked PRs for [Jujutsu](https://jj-vcs.github.io/jj/latest/). Push bookmark stacks to GitHub, GitLab, and Azure DevOps as chained pull requests.
 
 ## What it does
 
@@ -69,11 +69,31 @@ Uses (in order):
 
 For self-hosted: `export GITLAB_HOST=gitlab.mycompany.com`
 
+### Azure DevOps
+
+Uses (in order):
+1. `AZURE_DEVOPS_PAT` env var (recommended)
+2. `AZURE_DEVOPS_TOKEN` env var
+3. `az devops configure` (Azure CLI)
+
+**Setup:**
+
+1. Create a Personal Access Token at `https://dev.azure.com/{your-org}/_usersSettings/tokens`
+   - Scopes required: **Code (Read & Write)** and **Pull Requests (Read & Write)**
+2. Set environment variables:
+   ```sh
+   export AZURE_DEVOPS_PAT="your-token"
+   export AZURE_DEVOPS_ORGANIZATION="YourOrg"  # Optional but recommended for auth test
+   ```
+
+For self-hosted: `export AZURE_DEVOPS_HOST=your-server.com`
+
 ### Test authentication
 
 ```sh
 ryu auth github test
 ryu auth gitlab test
+ryu auth azure-devops test
 ```
 
 ## Usage

--- a/src/auth/azure_devops.rs
+++ b/src/auth/azure_devops.rs
@@ -1,0 +1,163 @@
+//! Azure DevOps authentication
+
+use crate::auth::AuthSource;
+use crate::error::{Error, Result};
+use base64::Engine;
+use reqwest::Client;
+use serde::Deserialize;
+use std::env;
+use tokio::process::Command;
+use tracing::debug;
+
+/// Azure DevOps authentication configuration
+#[derive(Debug, Clone)]
+pub struct AzureDevOpsAuthConfig {
+    /// Authentication token (Personal Access Token)
+    pub token: String,
+    /// Where the token was obtained from
+    pub source: AuthSource,
+    /// Azure DevOps host (e.g., "dev.azure.com")
+    pub host: String,
+    /// Optional organization for validation
+    pub organization: Option<String>,
+}
+
+/// Get Azure DevOps authentication
+///
+/// Priority:
+/// 1. `AZURE_DEVOPS_PAT` environment variable (recommended)
+/// 2. `AZURE_DEVOPS_TOKEN` environment variable
+/// 3. az devops CLI (`az devops configure --defaults`)
+pub async fn get_azure_devops_auth(host: Option<&str>) -> Result<AzureDevOpsAuthConfig> {
+    let host = host
+        .map(String::from)
+        .or_else(|| env::var("AZURE_DEVOPS_HOST").ok())
+        .unwrap_or_else(|| "dev.azure.com".to_string());
+
+    // Try to get organization from environment for validation
+    let organization = env::var("AZURE_DEVOPS_ORGANIZATION").ok();
+
+    // Try environment variables first (most common and reliable)
+    debug!("checking AZURE_DEVOPS_PAT env var");
+    if let Ok(token) = env::var("AZURE_DEVOPS_PAT") {
+        debug!("obtained Azure DevOps PAT from AZURE_DEVOPS_PAT env var");
+        return Ok(AzureDevOpsAuthConfig {
+            token: token.trim().to_string(), // Trim whitespace
+            source: AuthSource::EnvVar,
+            host,
+            organization,
+        });
+    }
+
+    debug!("checking AZURE_DEVOPS_TOKEN env var");
+    if let Ok(token) = env::var("AZURE_DEVOPS_TOKEN") {
+        debug!("obtained Azure DevOps token from AZURE_DEVOPS_TOKEN env var");
+        return Ok(AzureDevOpsAuthConfig {
+            token: token.trim().to_string(), // Trim whitespace
+            source: AuthSource::EnvVar,
+            host,
+            organization,
+        });
+    }
+
+    // Try az devops CLI as fallback
+    debug!(host = %host, "environment variables not found, attempting to get Azure DevOps token via az CLI");
+    if let Some(token) = get_az_cli_token().await {
+        debug!("obtained Azure DevOps token from az CLI");
+        return Ok(AzureDevOpsAuthConfig {
+            token,
+            source: AuthSource::Cli,
+            host,
+            organization,
+        });
+    }
+
+    debug!("no Azure DevOps authentication found");
+    Err(Error::Auth(
+        "No Azure DevOps authentication found. Create a PAT at https://dev.azure.com/{org}/_usersSettings/tokens and set AZURE_DEVOPS_PAT".to_string(),
+    ))
+}
+
+async fn get_az_cli_token() -> Option<String> {
+    // Check az is available
+    Command::new("az").arg("--version").output().await.ok()?;
+
+    // Check if Azure DevOps extension is configured
+    let output = Command::new("az")
+        .args(["devops", "configure", "--list"])
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    // Try to extract PAT from defaults
+    // Note: This is best-effort; az CLI doesn't store PATs by default
+    // Users should use environment variables for reliable authentication
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if line.contains("token") && line.contains('=') {
+            let parts: Vec<&str> = line.split('=').collect();
+            if parts.len() == 2 {
+                let token = parts[1].trim().to_string();
+                if !token.is_empty() {
+                    return Some(token);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+
+/// Test Azure DevOps authentication
+pub async fn test_azure_devops_auth(config: &AzureDevOpsAuthConfig) -> Result<String> {
+    // If we have an organization, use the organization-scoped endpoint
+    // Otherwise use the profile endpoint which works without organization
+    let url = if let Some(ref org) = config.organization {
+        format!("https://{}/{}/_apis/connectionData?api-version=7.1-preview", config.host, org)
+    } else {
+        // Use profile endpoint as fallback (works at account level)
+        format!("https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1-preview")
+    };
+
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| Error::AzureDevOpsApi(format!("failed to create HTTP client: {e}")))?;
+
+    // Azure DevOps uses Basic auth with empty username and PAT as password
+    let auth_header = format!(":{}", config.token);
+    let encoded = base64::engine::general_purpose::STANDARD.encode(auth_header);
+
+    let response: serde_json::Value = client
+        .get(&url)
+        .header("Authorization", format!("Basic {encoded}"))
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| Error::Auth(format!("Invalid token: {e}")))?
+        .json()
+        .await?;
+
+    // Extract authenticated user display name based on endpoint used
+    let display_name = if config.organization.is_some() {
+        response
+            .get("authenticatedUser")
+            .and_then(|u| u.get("providerDisplayName"))
+            .and_then(|n| n.as_str())
+            .unwrap_or("Unknown User")
+            .to_string()
+    } else {
+        response
+            .get("displayName")
+            .and_then(|n| n.as_str())
+            .unwrap_or("Unknown User")
+            .to_string()
+    };
+
+    Ok(display_name)
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Supports CLI-based auth (gh, glab) and environment variables.
 
+mod azure_devops;
 mod github;
 mod gitlab;
 
-pub use github::{GitHubAuthConfig, get_github_auth, test_github_auth};
-pub use gitlab::{GitLabAuthConfig, get_gitlab_auth, test_gitlab_auth};
+pub use azure_devops::{get_azure_devops_auth, test_azure_devops_auth, AzureDevOpsAuthConfig};
+pub use github::{get_github_auth, test_github_auth, GitHubAuthConfig};
+pub use gitlab::{get_gitlab_auth, test_gitlab_auth, GitLabAuthConfig};
 
 /// Source of authentication token
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,10 @@ pub enum Error {
     #[error("GitHub client error: {0}")]
     Octocrab(#[from] octocrab::Error),
 
+    /// Azure DevOps API error
+    #[error("Azure DevOps API error: {0}")]
+    AzureDevOpsApi(String),
+
     /// Platform API error (generic)
     #[error("platform error: {0}")]
     Platform(String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod cli;
 
 #[derive(Parser)]
 #[command(name = "ryu")]
-#[command(about = "Stacked PRs for Jujutsu - GitHub & GitLab")]
+#[command(about = "Stacked PRs for Jujutsu - GitHub, GitLab & Azure DevOps")]
 #[command(version)]
 struct Cli {
     /// Path to jj repository (defaults to current directory)
@@ -140,6 +140,12 @@ enum AuthPlatform {
         #[command(subcommand)]
         action: AuthAction,
     },
+    /// Azure DevOps authentication
+    #[command(name = "azure-devops")]
+    AzureDevops {
+        #[command(subcommand)]
+        action: AuthAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -235,6 +241,13 @@ async fn main() -> Result<()> {
                     AuthAction::Setup => "setup",
                 };
                 cli::run_auth(Platform::GitLab, action_str).await?;
+            }
+            AuthPlatform::AzureDevops { action } => {
+                let action_str = match action {
+                    AuthAction::Test => "test",
+                    AuthAction::Setup => "setup",
+                };
+                cli::run_auth(Platform::AzureDevOps, action_str).await?;
             }
         },
         Some(Commands::Track {

--- a/src/platform/azure_devops.rs
+++ b/src/platform/azure_devops.rs
@@ -1,0 +1,464 @@
+//! Azure DevOps platform service implementation
+
+use crate::error::{Error, Result};
+use crate::platform::PlatformService;
+use crate::types::{Platform, PlatformConfig, PrComment, PullRequest};
+use async_trait::async_trait;
+use base64::Engine;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Azure DevOps service using reqwest
+pub struct AzureDevOpsService {
+    client: Client,
+    token: String,
+    host: String,
+    config: PlatformConfig,
+    organization: String,
+    #[allow(dead_code)]
+    project: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestResponse {
+    pull_request_id: u64,
+    #[serde(rename = "url")]
+    _api_url: String,
+    source_ref_name: String,
+    target_ref_name: String,
+    title: String,
+    #[serde(default)]
+    is_draft: bool,
+    repository: Repository,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Repository {
+    web_url: String,
+}
+
+impl PullRequestResponse {
+    fn into_pull_request(self) -> PullRequest {
+        // Strip refs/heads/ prefix from branch names
+        let source_branch = self
+            .source_ref_name
+            .strip_prefix("refs/heads/")
+            .unwrap_or(&self.source_ref_name)
+            .to_string();
+        let target_branch = self
+            .target_ref_name
+            .strip_prefix("refs/heads/")
+            .unwrap_or(&self.target_ref_name)
+            .to_string();
+
+        let html_url = format!(
+            "{}/pullrequest/{}",
+            self.repository.web_url.trim_end_matches('/'),
+            self.pull_request_id
+        );
+
+        PullRequest {
+            number: self.pull_request_id,
+            html_url,
+            base_ref: target_branch,
+            head_ref: source_branch,
+            title: self.title,
+            node_id: None,
+            is_draft: self.is_draft,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct PullRequestListResponse {
+    value: Vec<PullRequestResponse>,
+}
+
+#[derive(Deserialize)]
+struct Thread {
+    id: u64,
+    comments: Vec<Comment>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Comment {
+    id: u64,
+    content: String,
+    #[serde(rename = "commentType")]
+    type_id: u32, // 1 = text, 2 = system
+}
+
+#[derive(Deserialize)]
+struct ThreadListResponse {
+    value: Vec<Thread>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreatePrPayload {
+    source_ref_name: String,
+    target_ref_name: String,
+    title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_draft: Option<bool>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateThreadPayload {
+    comments: Vec<CreateCommentPayload>,
+    status: u32, // 1 = active
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateCommentPayload {
+    parent_comment_id: u32, // 0 for root
+    content: String,
+    comment_type: u32, // 1 = text
+}
+
+/// Default request timeout in seconds
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+impl AzureDevOpsService {
+    /// Create a new Azure DevOps service
+    ///
+    /// # Arguments
+    /// * `token` - Personal Access Token
+    /// * `organization` - Azure DevOps organization name
+    /// * `project` - Project name
+    /// * `repo` - Repository name
+    /// * `host` - Optional host (defaults to dev.azure.com)
+    pub fn new(
+        token: String,
+        organization: String,
+        project: String,
+        repo: String,
+        host: Option<String>,
+    ) -> Result<Self> {
+        let host = host.unwrap_or_else(|| "dev.azure.com".to_string());
+
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| Error::AzureDevOpsApi(format!("failed to create HTTP client: {e}")))?;
+
+        let config_host = if host == "dev.azure.com" {
+            None
+        } else {
+            Some(host.clone())
+        };
+
+        Ok(Self {
+            client,
+            token,
+            host,
+            config: PlatformConfig {
+                platform: Platform::AzureDevOps,
+                owner: format!("{organization}/{project}"),
+                repo,
+                host: config_host,
+            },
+            organization,
+            project,
+        })
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!(
+            "https://{}/{}/{}/_apis{}",
+            self.host, self.organization, self.project, path
+        )
+    }
+
+    fn auth_header(&self) -> String {
+        let auth = format!(":{}", self.token);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(auth);
+        format!("Basic {encoded}")
+    }
+
+    fn branch_ref(branch: &str) -> String {
+        if branch.starts_with("refs/") {
+            branch.to_string()
+        } else {
+            format!("refs/heads/{branch}")
+        }
+    }
+}
+
+#[async_trait]
+impl PlatformService for AzureDevOpsService {
+    async fn find_existing_pr(&self, head_branch: &str) -> Result<Option<PullRequest>> {
+        debug!(head_branch, "finding existing PR");
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests",
+            urlencoding::encode(&self.config.repo)
+        ));
+
+        let source_ref = Self::branch_ref(head_branch);
+
+        let response: PullRequestListResponse = self
+            .client
+            .get(&url)
+            .header("Authorization", self.auth_header())
+            .query(&[
+                ("searchCriteria.sourceRefName", source_ref.as_str()),
+                ("searchCriteria.status", "active"),
+                ("api-version", "7.1-preview"),
+            ])
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?
+            .json()
+            .await?;
+
+        let result: Option<PullRequest> = response
+            .value
+            .into_iter()
+            .next()
+            .map(PullRequestResponse::into_pull_request);
+
+        if let Some(ref pr) = result {
+            debug!(pr_id = pr.number, "found existing PR");
+        } else {
+            debug!("no existing PR found");
+        }
+        Ok(result)
+    }
+
+    async fn create_pr_with_options(
+        &self,
+        head: &str,
+        base: &str,
+        title: &str,
+        draft: bool,
+    ) -> Result<PullRequest> {
+        debug!(head, base, draft, "creating PR");
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests",
+            urlencoding::encode(&self.config.repo)
+        ));
+
+        let payload = CreatePrPayload {
+            source_ref_name: Self::branch_ref(head),
+            target_ref_name: Self::branch_ref(base),
+            title: title.to_string(),
+            is_draft: if draft { Some(true) } else { None },
+        };
+
+        let pr: PullRequestResponse = self
+            .client
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .query(&[("api-version", "7.1-preview")])
+            .json(&payload)
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?
+            .json()
+            .await?;
+
+        let result = pr.into_pull_request();
+        debug!(pr_id = result.number, "created PR");
+        Ok(result)
+    }
+
+    async fn update_pr_base(&self, pr_number: u64, new_base: &str) -> Result<PullRequest> {
+        debug!(pr_id = pr_number, new_base, "updating PR base");
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests/{}",
+            urlencoding::encode(&self.config.repo),
+            pr_number
+        ));
+
+        let pr: PullRequestResponse = self
+            .client
+            .patch(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .query(&[("api-version", "7.1-preview")])
+            .json(&serde_json::json!({ "targetRefName": Self::branch_ref(new_base) }))
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?
+            .json()
+            .await?;
+
+        debug!(pr_id = pr_number, "updated PR base");
+        Ok(pr.into_pull_request())
+    }
+
+    async fn publish_pr(&self, pr_number: u64) -> Result<PullRequest> {
+        debug!(pr_id = pr_number, "publishing PR");
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests/{}",
+            urlencoding::encode(&self.config.repo),
+            pr_number
+        ));
+
+        let pr: PullRequestResponse = self
+            .client
+            .patch(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .query(&[("api-version", "7.1-preview")])
+            .json(&serde_json::json!({ "isDraft": false }))
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?
+            .json()
+            .await?;
+
+        debug!(pr_id = pr_number, "published PR");
+        Ok(pr.into_pull_request())
+    }
+
+    async fn list_pr_comments(&self, pr_number: u64) -> Result<Vec<PrComment>> {
+        debug!(pr_id = pr_number, "listing PR comments");
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests/{}/threads",
+            urlencoding::encode(&self.config.repo),
+            pr_number
+        ));
+
+        let response: ThreadListResponse = self
+            .client
+            .get(&url)
+            .header("Authorization", self.auth_header())
+            .query(&[("api-version", "7.1-preview")])
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?
+            .json()
+            .await?;
+
+        // Flatten threads to comments, filtering out system comments
+        let comments: Vec<PrComment> = response
+            .value
+            .into_iter()
+            .flat_map(|thread| {
+                thread.comments.into_iter().filter_map(|comment| {
+                    // Only include text comments (type 1), not system comments (type 2)
+                    if comment.type_id == 1 {
+                        Some(PrComment {
+                            id: comment.id,
+                            body: comment.content,
+                        })
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        debug!(
+            pr_id = pr_number,
+            count = comments.len(),
+            "listed PR comments"
+        );
+        Ok(comments)
+    }
+
+    async fn create_pr_comment(&self, pr_number: u64, body: &str) -> Result<()> {
+        debug!(pr_id = pr_number, "creating PR comment");
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests/{}/threads",
+            urlencoding::encode(&self.config.repo),
+            pr_number
+        ));
+
+        let payload = CreateThreadPayload {
+            comments: vec![CreateCommentPayload {
+                parent_comment_id: 0,
+                content: body.to_string(),
+                comment_type: 1,
+            }],
+            status: 1, // active
+        };
+
+        self.client
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .query(&[("api-version", "7.1-preview")])
+            .json(&payload)
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?;
+
+        debug!(pr_id = pr_number, "created PR comment");
+        Ok(())
+    }
+
+    async fn update_pr_comment(&self, pr_number: u64, comment_id: u64, body: &str) -> Result<()> {
+        debug!(pr_id = pr_number, comment_id, "updating PR comment");
+
+        // Azure DevOps requires thread ID to update a comment
+        // We need to find which thread contains this comment
+        let threads_url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests/{}/threads",
+            urlencoding::encode(&self.config.repo),
+            pr_number
+        ));
+
+        let response: ThreadListResponse = self
+            .client
+            .get(&threads_url)
+            .header("Authorization", self.auth_header())
+            .query(&[("api-version", "7.1-preview")])
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?
+            .json()
+            .await?;
+
+        // Find the thread containing this comment
+        let thread_id = response
+            .value
+            .iter()
+            .find(|thread| thread.comments.iter().any(|c| c.id == comment_id))
+            .map(|thread| thread.id)
+            .ok_or_else(|| {
+                Error::AzureDevOpsApi(format!("comment {comment_id} not found in any thread"))
+            })?;
+
+        let url = self.api_url(&format!(
+            "/git/repositories/{}/pullrequests/{}/threads/{}/comments/{}",
+            urlencoding::encode(&self.config.repo),
+            pr_number,
+            thread_id,
+            comment_id
+        ));
+
+        self.client
+            .patch(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .query(&[("api-version", "7.1-preview")])
+            .json(&serde_json::json!({ "content": body }))
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| Error::AzureDevOpsApi(e.to_string()))?;
+
+        debug!(pr_id = pr_number, comment_id, "updated PR comment");
+        Ok(())
+    }
+
+    fn config(&self) -> &PlatformConfig {
+        &self.config
+    }
+}

--- a/src/platform/detection.rs
+++ b/src/platform/detection.rs
@@ -14,12 +14,35 @@ static RE_SSH: LazyLock<Regex> =
 static RE_HTTPS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"https?://[^/]+/(.+?)(?:\.git)?$").unwrap());
 
+/// Regex for Azure DevOps SSH URLs: git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+static RE_AZURE_SSH: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"git@ssh\.dev\.azure\.com:v3/([^/]+)/([^/]+)/(.+?)(?:\.git)?$").unwrap());
+
+/// Regex for Azure DevOps HTTPS URLs: `<https://dev.azure.com/{org}/{project}/_git/{repo}>`
+/// Supports optional username prefix and URL-encoded characters
+static RE_AZURE_HTTPS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"https?://(?:[^@]+@)?dev\.azure\.com/([^/]+)/([^/]+)/_git/(.+?)(?:\.git)?$").unwrap());
+
 /// Detect platform (GitHub or GitLab) from a remote URL
 pub fn detect_platform(url: &str) -> Option<Platform> {
     let gh_host = env::var("GH_HOST").ok();
     let gitlab_host = env::var("GITLAB_HOST").ok();
+    let azure_host = env::var("AZURE_DEVOPS_HOST").ok();
+
+    // Check Azure DevOps patterns first (more specific)
+    if RE_AZURE_SSH.is_match(url) || RE_AZURE_HTTPS.is_match(url) {
+        return Some(Platform::AzureDevOps);
+    }
 
     let hostname = extract_hostname(url)?;
+
+    // Check Azure DevOps hostnames
+    if hostname == "dev.azure.com"
+        || hostname == "ssh.dev.azure.com"
+        || azure_host.as_ref().is_some_and(|h| hostname == *h)
+    {
+        return Some(Platform::AzureDevOps);
+    }
 
     // Check GitHub
     if hostname == "github.com"
@@ -46,6 +69,12 @@ pub fn parse_repo_info(url: &str) -> Result<PlatformConfig> {
     let url = url.trim_end_matches('/');
 
     let platform = detect_platform(url).ok_or(Error::NoSupportedRemotes)?;
+
+    // Handle Azure DevOps specially (different structure)
+    if platform == Platform::AzureDevOps {
+        return parse_azure_devops_url(url);
+    }
+
     let hostname = extract_hostname(url);
 
     let path = RE_SSH
@@ -80,6 +109,7 @@ pub fn parse_repo_info(url: &str) -> Result<PlatformConfig> {
                 None
             }
         }
+        Platform::AzureDevOps => unreachable!("Azure DevOps handled above"),
     };
 
     Ok(PlatformConfig {
@@ -88,6 +118,46 @@ pub fn parse_repo_info(url: &str) -> Result<PlatformConfig> {
         repo,
         host,
     })
+}
+
+fn parse_azure_devops_url(url: &str) -> Result<PlatformConfig> {
+    // Try SSH format first: git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+    if let Some(caps) = RE_AZURE_SSH.captures(url) {
+        let org = urlencoding::decode(caps.get(1).unwrap().as_str())
+            .map_err(|e| Error::Parse(format!("invalid URL encoding in org: {e}")))?;
+        let project = urlencoding::decode(caps.get(2).unwrap().as_str())
+            .map_err(|e| Error::Parse(format!("invalid URL encoding in project: {e}")))?;
+        let repo = urlencoding::decode(caps.get(3).unwrap().as_str())
+            .map_err(|e| Error::Parse(format!("invalid URL encoding in repo: {e}")))?;
+
+        return Ok(PlatformConfig {
+            platform: Platform::AzureDevOps,
+            owner: format!("{org}/{project}"),
+            repo: repo.to_string(),
+            host: None,
+        });
+    }
+
+    // Try HTTPS format: https://dev.azure.com/{org}/{project}/_git/{repo}
+    if let Some(caps) = RE_AZURE_HTTPS.captures(url) {
+        let org = urlencoding::decode(caps.get(1).unwrap().as_str())
+            .map_err(|e| Error::Parse(format!("invalid URL encoding in org: {e}")))?;
+        let project = urlencoding::decode(caps.get(2).unwrap().as_str())
+            .map_err(|e| Error::Parse(format!("invalid URL encoding in project: {e}")))?;
+        let repo = urlencoding::decode(caps.get(3).unwrap().as_str())
+            .map_err(|e| Error::Parse(format!("invalid URL encoding in repo: {e}")))?;
+
+        return Ok(PlatformConfig {
+            platform: Platform::AzureDevOps,
+            owner: format!("{org}/{project}"),
+            repo: repo.to_string(),
+            host: None,
+        });
+    }
+
+    Err(Error::Parse(format!(
+        "cannot parse Azure DevOps URL: {url}"
+    )))
 }
 
 fn extract_hostname(url: &str) -> Option<String> {
@@ -148,5 +218,65 @@ mod tests {
         assert_eq!(config.platform, Platform::GitLab);
         assert_eq!(config.owner, "group/subgroup");
         assert_eq!(config.repo, "repo");
+    }
+
+    #[test]
+    fn test_detect_azure_devops_https() {
+        assert_eq!(
+            detect_platform("https://dev.azure.com/myorg/myproject/_git/myrepo"),
+            Some(Platform::AzureDevOps)
+        );
+    }
+
+    #[test]
+    fn test_detect_azure_devops_ssh() {
+        assert_eq!(
+            detect_platform("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo"),
+            Some(Platform::AzureDevOps)
+        );
+    }
+
+    #[test]
+    fn test_parse_azure_devops_https() {
+        let config =
+            parse_repo_info("https://dev.azure.com/myorg/myproject/_git/myrepo.git").unwrap();
+        assert_eq!(config.platform, Platform::AzureDevOps);
+        assert_eq!(config.owner, "myorg/myproject");
+        assert_eq!(config.repo, "myrepo");
+        assert!(config.host.is_none());
+    }
+
+    #[test]
+    fn test_parse_azure_devops_ssh() {
+        let config =
+            parse_repo_info("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo.git").unwrap();
+        assert_eq!(config.platform, Platform::AzureDevOps);
+        assert_eq!(config.owner, "myorg/myproject");
+        assert_eq!(config.repo, "myrepo");
+        assert!(config.host.is_none());
+    }
+
+    #[test]
+    fn test_parse_azure_devops_with_username() {
+        // Test URL with username prefix
+        let config =
+            parse_repo_info("https://user@dev.azure.com/myorg/myproject/_git/myrepo")
+                .unwrap();
+        assert_eq!(config.platform, Platform::AzureDevOps);
+        assert_eq!(config.owner, "myorg/myproject");
+        assert_eq!(config.repo, "myrepo");
+        assert!(config.host.is_none());
+    }
+
+    #[test]
+    fn test_parse_azure_devops_with_url_encoding() {
+        // Test URL with URL-encoded space in project name
+        let config =
+            parse_repo_info("https://dev.azure.com/myorg/My%20Project/_git/myrepo.git")
+                .unwrap();
+        assert_eq!(config.platform, Platform::AzureDevOps);
+        assert_eq!(config.owner, "myorg/My Project");
+        assert_eq!(config.repo, "myrepo");
+        assert!(config.host.is_none());
     }
 }

--- a/src/platform/factory.rs
+++ b/src/platform/factory.rs
@@ -2,9 +2,9 @@
 //!
 //! Creates platform services based on configuration.
 
-use crate::auth::{get_github_auth, get_gitlab_auth};
+use crate::auth::{get_azure_devops_auth, get_github_auth, get_gitlab_auth};
 use crate::error::Result;
-use crate::platform::{GitHubService, GitLabService, PlatformService};
+use crate::platform::{AzureDevOpsService, GitHubService, GitLabService, PlatformService};
 use crate::types::{Platform, PlatformConfig};
 
 /// Create a platform service from configuration
@@ -26,6 +26,24 @@ pub async fn create_platform_service(config: &PlatformConfig) -> Result<Box<dyn 
             Ok(Box::new(GitLabService::new(
                 auth.token.clone(),
                 config.owner.clone(),
+                config.repo.clone(),
+                Some(auth.host),
+            )?))
+        }
+        Platform::AzureDevOps => {
+            let auth = get_azure_devops_auth(config.host.as_deref()).await?;
+            // Parse owner as org/project
+            let parts: Vec<&str> = config.owner.split('/').collect();
+            if parts.len() != 2 {
+                return Err(crate::error::Error::Config(format!(
+                    "Azure DevOps owner must be in format 'org/project', got: {}",
+                    config.owner
+                )));
+            }
+            Ok(Box::new(AzureDevOpsService::new(
+                auth.token.clone(),
+                parts[0].to_string(),
+                parts[1].to_string(),
                 config.repo.clone(),
                 Some(auth.host),
             )?))

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Provides a unified interface for PR/MR operations across platforms.
 
+mod azure_devops;
 mod detection;
 mod factory;
 mod github;
 mod gitlab;
 
+pub use azure_devops::AzureDevOpsService;
 pub use detection::{detect_platform, parse_repo_info};
 pub use factory::create_platform_service;
 pub use github::GitHubService;

--- a/src/types.rs
+++ b/src/types.rs
@@ -129,6 +129,8 @@ pub enum Platform {
     GitHub,
     /// GitLab or self-hosted GitLab
     GitLab,
+    /// Azure DevOps
+    AzureDevOps,
 }
 
 impl std::fmt::Display for Platform {
@@ -136,6 +138,7 @@ impl std::fmt::Display for Platform {
         match self {
             Self::GitHub => write!(f, "GitHub"),
             Self::GitLab => write!(f, "GitLab"),
+            Self::AzureDevOps => write!(f, "Azure DevOps"),
         }
     }
 }


### PR DESCRIPTION
Adds Azure Devops integration, mostly cause I want to use ryu at work and we sadly use devops (F in the chat boys).

I'm opening this, but I'd rather do some testing still (theres some ADO specific issues with PR's and the stack comment linking work items from the platform, which in many cases wont be equal to the created PR number so I also want to discuss the idea of then adding backticks for azure specific ops to wrap the PR number in something that wont be picked up as an in-platform link to some (potentially non-existent) work item number (like in our case, we use jira too for that) or that the work items aren't in sync with the PR's (which I'd like to assume is going to always be the case)

Let me know thoughts, and send prayers for me having to use ADO daily

Edit;
also my first major check in on how claude works, and I probably messed up _alot_, just adding this for transparency.