### PR TITLE
fix: resolve workspace root from subdirs

### DIFF
--- a/src/repo/workspace.rs
+++ b/src/repo/workspace.rs
@@ -57,14 +57,22 @@ fn create_user_settings() -> Result<UserSettings> {
         .map_err(|e| Error::Config(format!("Failed to create settings: {e}")))
 }
 
+/// Finds the nearest workspace root by walking up the directory tree.
+fn find_workspace_dir(path: &Path) -> &Path {
+    path.ancestors()
+        .find(|path| path.join(".jj").is_dir())
+        .unwrap_or(path)
+}
+
 impl JjWorkspace {
     /// Open a jj workspace at the given path
     pub fn open(path: &Path) -> Result<Self> {
         let settings = create_user_settings()?;
+        let workspace_root = find_workspace_dir(path);
 
         let workspace = Workspace::load(
             &settings,
-            path,
+            &workspace_root,
             &StoreFactories::default(),
             &default_working_copy_factories(),
         )

--- a/tests/common/temp_repo.rs
+++ b/tests/common/temp_repo.rs
@@ -202,6 +202,19 @@ mod tests {
     }
 
     #[test]
+    fn test_open_workspace_from_subdir() {
+        let repo = TempJjRepo::new();
+        let subdir = repo.path().join("nested");
+        std::fs::create_dir_all(&subdir).expect("create subdir");
+
+        let workspace = JjWorkspace::open(&subdir).expect("open workspace from subdir");
+        let workspace_root =
+            std::fs::canonicalize(workspace.workspace_root()).expect("canonicalize workspace root");
+        let repo_root = std::fs::canonicalize(repo.path()).expect("canonicalize repo root");
+        assert_eq!(workspace_root, repo_root);
+    }
+
+    #[test]
     fn test_create_bookmark() {
         let repo = TempJjRepo::new();
         repo.commit("test commit");


### PR DESCRIPTION
Fix running `ryu` from subdirectories by resolving the workspace root.

### Problem
Running `ryu` outside the repo root failed with:
  "Error: workspace error: Failed to open workspace: There is no Jujutsu repo in ."

```
repo-root/
├── .jj/
└── subdir/          ← (run from here)
    └── ...
```

### Solution
`ryu` walks up the directory tree to find the nearest `.jj` workspace root.

