### PR TITLE
fix: honor glab config for GitLab auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,6 +2076,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "supports-hyperlinks",
  "tempfile",
@@ -3118,6 +3119,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,6 +3761,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ octocrab = { version = "0.47", default-features = false, features = ["rustls", "
 # serialization + utilities
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 thiserror = "2.0"
 anyhow = "1"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ For GitHub Enterprise: `export GH_HOST=github.mycompany.com`
 ### GitLab
 
 Uses (in order):
-1. `glab auth token` (GitLab CLI)
+1. `glab auth status --show-token` (GitLab CLI)
 2. `GITLAB_TOKEN` env var
 3. `GL_TOKEN` env var
 
-For self-hosted: `export GITLAB_HOST=gitlab.mycompany.com`
+Self-hosted GitLab is auto-detected from your `glab` config
+(`~/.config/glab-cli/config.yml`). To override, set `GITLAB_HOST`.
 
 ### Test authentication
 

--- a/src/auth/gitlab.rs
+++ b/src/auth/gitlab.rs
@@ -72,20 +72,8 @@ async fn get_glab_cli_token(host: &str) -> Option<String> {
     // Check glab is available
     Command::new("glab").arg("--version").output().await.ok()?;
 
-    // Check authenticated
-    let status = Command::new("glab")
-        .args(["auth", "status", "--hostname", host])
-        .output()
-        .await
-        .ok()?;
-
-    if !status.status.success() {
-        return None;
-    }
-
-    // Get token
     let output = Command::new("glab")
-        .args(["auth", "token", "--hostname", host])
+        .args(["auth", "status", "--hostname", host, "--show-token"])
         .output()
         .await
         .ok()?;
@@ -94,8 +82,28 @@ async fn get_glab_cli_token(host: &str) -> Option<String> {
         return None;
     }
 
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if token.is_empty() { None } else { Some(token) }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+    extract_token_from_glab_status(&combined)
+}
+
+fn extract_token_from_glab_status(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        let token_start = trimmed
+            .find("Token found:")
+            .map(|idx| idx + "Token found:".len())
+            .or_else(|| trimmed.find("Token:").map(|idx| idx + "Token:".len()));
+
+        if let Some(start) = token_start {
+            let token = trimmed[start..].trim();
+            if !token.is_empty() {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
 }
 
 #[derive(Deserialize)]

--- a/src/platform/detection.rs
+++ b/src/platform/detection.rs
@@ -3,7 +3,11 @@
 use crate::error::{Error, Result};
 use crate::types::{Platform, PlatformConfig};
 use regex::Regex;
+use serde_yaml::Value;
+use std::collections::HashSet;
 use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 /// Regex for SSH URLs: git@host:owner/repo.git
@@ -20,11 +24,13 @@ pub fn detect_platform(url: &str) -> Option<Platform> {
     let gitlab_host = env::var("GITLAB_HOST").ok();
 
     let hostname = extract_hostname(url)?;
+    let cli_hosts = load_cli_hosts();
 
     // Check GitHub
     if hostname == "github.com"
         || hostname.ends_with(".github.com")
         || gh_host.as_ref().is_some_and(|h| hostname == *h)
+        || cli_hosts.github.contains(&hostname)
     {
         return Some(Platform::GitHub);
     }
@@ -33,6 +39,7 @@ pub fn detect_platform(url: &str) -> Option<Platform> {
     if hostname == "gitlab.com"
         || hostname.ends_with(".gitlab.com")
         || gitlab_host.as_ref().is_some_and(|h| hostname == *h)
+        || cli_hosts.gitlab.contains(&hostname)
     {
         return Some(Platform::GitLab);
     }
@@ -61,7 +68,7 @@ pub fn parse_repo_info(url: &str) -> Result<PlatformConfig> {
         return Err(Error::Parse(format!("invalid repo path: {path}")));
     }
 
-    let repo = parts.last().unwrap().to_string();
+    let repo = (*parts.last().unwrap()).to_string();
     let owner = parts[..parts.len() - 1].join("/");
 
     // Determine if self-hosted
@@ -105,9 +112,109 @@ fn extract_hostname(url: &str) -> Option<String> {
         .and_then(|u| u.host_str().map(ToString::to_string))
 }
 
+#[derive(Default)]
+struct CliHosts {
+    github: HashSet<String>,
+    gitlab: HashSet<String>,
+}
+
+fn load_cli_hosts() -> CliHosts {
+    let mut candidates = Vec::new();
+
+    if let Ok(xdg_config_home) = env::var("XDG_CONFIG_HOME") {
+        candidates.push(PathBuf::from(xdg_config_home));
+    }
+
+    if let Some(config_dir) = dirs::config_dir() {
+        candidates.push(config_dir);
+    }
+
+    if let Some(home_dir) = dirs::home_dir() {
+        candidates.push(home_dir.join(".config"));
+    }
+
+    load_cli_hosts_from_dirs(candidates)
+}
+
+fn load_cli_hosts_from_dirs<I>(dirs: I) -> CliHosts
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    let mut hosts = CliHosts::default();
+    let mut seen = HashSet::new();
+
+    for dir in dirs {
+        if !seen.insert(dir.clone()) {
+            continue;
+        }
+
+        add_github_hosts(&dir.join("gh/hosts.yml"), &mut hosts.github);
+        add_gitlab_hosts(&dir.join("glab-cli/config.yml"), &mut hosts.gitlab);
+    }
+
+    hosts
+}
+
+fn add_github_hosts(path: &Path, hosts: &mut HashSet<String>) {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(value) = serde_yaml::from_str::<Value>(&contents) else {
+        return;
+    };
+
+    let Value::Mapping(map) = value else {
+        return;
+    };
+
+    for (key, _) in map {
+        if let Value::String(host) = key {
+            hosts.insert(host);
+        }
+    }
+}
+
+fn add_gitlab_hosts(path: &Path, hosts: &mut HashSet<String>) {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(value) = serde_yaml::from_str::<Value>(&contents) else {
+        return;
+    };
+
+    let Value::Mapping(map) = value else {
+        return;
+    };
+
+    if let Some(Value::String(default_host)) = map.get(Value::String("host".to_string())) {
+        hosts.insert(default_host.clone());
+    }
+
+    let Some(Value::Mapping(hosts_map)) = map.get(Value::String("hosts".to_string())) else {
+        return;
+    };
+
+    for (key, value) in hosts_map {
+        if let Value::String(host) = key {
+            hosts.insert(host.clone());
+        }
+
+        let Value::Mapping(details) = value else {
+            continue;
+        };
+
+        if let Some(Value::String(api_host)) =
+            details.get(Value::String("api_host".to_string()))
+        {
+            hosts.insert(api_host.clone());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn test_detect_github_https() {
@@ -148,5 +255,38 @@ mod tests {
         assert_eq!(config.platform, Platform::GitLab);
         assert_eq!(config.owner, "group/subgroup");
         assert_eq!(config.repo, "repo");
+    }
+
+    #[test]
+    fn test_load_cli_hosts_from_glab_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path();
+        let glab_dir = config_dir.join("glab-cli");
+        fs::create_dir_all(&glab_dir).unwrap();
+        fs::write(
+            glab_dir.join("config.yml"),
+            "host: git.example.com\nhosts:\n  git.example.com:\n    api_host: api.git.example.com\n",
+        )
+        .unwrap();
+
+        let hosts = load_cli_hosts_from_dirs([config_dir.to_path_buf()]);
+        assert!(hosts.gitlab.contains("git.example.com"));
+        assert!(hosts.gitlab.contains("api.git.example.com"));
+    }
+
+    #[test]
+    fn test_load_cli_hosts_from_gh_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path();
+        let gh_dir = config_dir.join("gh");
+        fs::create_dir_all(&gh_dir).unwrap();
+        fs::write(
+            gh_dir.join("hosts.yml"),
+            "github.com:\n  user: octo\n  oauth_token: token\n",
+        )
+        .unwrap();
+
+        let hosts = load_cli_hosts_from_dirs([config_dir.to_path_buf()]);
+        assert!(hosts.github.contains("github.com"));
     }
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -260,6 +260,7 @@ mod detection_test {
     }
 }
 
+
 mod plan_test {
     use crate::common::{MockPlatformService, github_config, make_linear_stack, make_pr};
     use jj_ryu::submit::{ExecutionStep, analyze_submission, create_submission_plan};


### PR DESCRIPTION
## Summary
- detect self-hosted GitLab/GitHub hosts from CLI config files (glab/gh)
- read GitLab tokens via `glab auth status --show-token` (stderr-aware)
- adjust detection parsing to satisfy clippy

## Testing
- cargo test
- nix run nixpkgs#clippy -- clippy -- -D warnings
